### PR TITLE
Ignore resource links

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -126,7 +126,7 @@ class GlueSourceConfig(AwsSourceConfig, StatefulIngestionConfigBase):
         description="Whether to ignore unsupported connectors. If disabled, an error will be raised.",
     )
     emit_s3_lineage: bool = Field(
-        default=False, description=" Whether to emit S3-to-Glue lineage."
+        default=False, description="Whether to emit S3-to-Glue lineage."
     )
     glue_s3_lineage_direction: str = Field(
         default="upstream",
@@ -139,6 +139,10 @@ class GlueSourceConfig(AwsSourceConfig, StatefulIngestionConfigBase):
     catalog_id: Optional[str] = Field(
         default=None,
         description="The aws account id where the target glue catalog lives. If None, datahub will ingest glue in aws caller's account.",
+    )
+    ignore_resource_links: Optional[bool] = Field(
+        default=False,
+        description="If set to True, ignore database resource links.",
     )
     use_s3_bucket_tags: Optional[bool] = Field(
         default=False,
@@ -644,62 +648,59 @@ class GlueSource(StatefulIngestionSourceBase):
 
         return MetadataWorkUnit(id=f'{job_name}-{node["Id"]}', mce=mce)
 
-    def get_all_tables_and_databases(
+    def get_all_databases(self) -> Iterable[Mapping[str, Any]]:
+        # see https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue/paginator/GetDatabases.html
+        paginator = self.glue_client.get_paginator("get_databases")
+
+        if self.source_config.catalog_id:
+            paginator_response = paginator.paginate(
+                CatalogId=self.source_config.catalog_id
+            )
+        else:
+            paginator_response = paginator.paginate()
+
+        for page in paginator_response:
+            yield from page["DatabaseList"]
+
+    def get_tables_from_database(self, database_name: str) -> Iterable[Dict]:
+        # see https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue/paginator/GetTables.html
+        paginator = self.glue_client.get_paginator("get_tables")
+
+        if self.source_config.catalog_id:
+            paginator_response = paginator.paginate(
+                DatabaseName=database_name, CatalogId=self.source_config.catalog_id
+            )
+        else:
+            paginator_response = paginator.paginate(DatabaseName=database_name)
+
+        for page in paginator_response:
+            yield from page["TableList"]
+
+    def get_all_databases_and_tables(
         self,
     ) -> Tuple[Dict, List[Dict]]:
-        def get_tables_from_database(database_name: str) -> List[dict]:
-            new_tables = []
+        all_databases = self.get_all_databases()
 
-            # see https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue.html#Glue.Client.get_tables
-            paginator = self.glue_client.get_paginator("get_tables")
+        if self.source_config.ignore_resource_links:
+            all_databases = [
+                database
+                for database in all_databases
+                if "TargetDatabase" not in database
+            ]
 
-            if self.source_config.catalog_id:
-                paginator_response = paginator.paginate(
-                    DatabaseName=database_name, CatalogId=self.source_config.catalog_id
-                )
-            else:
-                paginator_response = paginator.paginate(DatabaseName=database_name)
-
-            for page in paginator_response:
-                new_tables += page["TableList"]
-
-            return new_tables
-
-        def get_databases() -> List[Mapping[str, Any]]:
-            databases = []
-
-            # see https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue.html#Glue.Client.get_databases
-            paginator = self.glue_client.get_paginator("get_databases")
-
-            if self.source_config.catalog_id:
-                paginator_response = paginator.paginate(
-                    CatalogId=self.source_config.catalog_id
-                )
-            else:
-                paginator_response = paginator.paginate()
-
-            for page in paginator_response:
-                for db in page["DatabaseList"]:
-                    if self.source_config.database_pattern.allowed(db["Name"]):
-                        databases.append(db)
-
-            return databases
-
-        all_databases = get_databases()
-
-        databases = {
+        allowed_databases = {
             database["Name"]: database
             for database in all_databases
             if self.source_config.database_pattern.allowed(database["Name"])
         }
 
-        all_tables: List[dict] = [
+        all_tables = [
             table
-            for databaseName in databases.keys()
-            for table in get_tables_from_database(databaseName)
+            for database_name in allowed_databases
+            for table in self.get_tables_from_database(database_name)
         ]
 
-        return databases, all_tables
+        return allowed_databases, all_tables
 
     def get_lineage_if_enabled(
         self, mce: MetadataChangeEventClass
@@ -952,7 +953,7 @@ class GlueSource(StatefulIngestionSourceBase):
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         database_seen = set()
-        databases, tables = self.get_all_tables_and_databases()
+        databases, tables = self.get_all_databases_and_tables()
 
         for table in tables:
             database_name = table["DatabaseName"]

--- a/metadata-ingestion/tests/unit/test_glue_source.py
+++ b/metadata-ingestion/tests/unit/test_glue_source.py
@@ -35,6 +35,7 @@ from tests.unit.test_glue_source_stubs import (
     databases_2,
     get_bucket_tagging,
     get_databases_response,
+    get_databases_response_with_resource_link,
     get_dataflow_graph_response_1,
     get_dataflow_graph_response_2,
     get_jobs_response,
@@ -45,8 +46,11 @@ from tests.unit.test_glue_source_stubs import (
     get_object_tagging,
     get_tables_response_1,
     get_tables_response_2,
+    get_tables_response_for_target_database,
+    resource_link_database,
     tables_1,
     tables_2,
+    target_database_tables,
 )
 
 FROZEN_TIME = "2020-04-14 07:00:00"
@@ -199,6 +203,37 @@ def test_platform_takes_precendence_over_underlying_platform():
     assert source.platform == "athena"
 
 
+@pytest.mark.parametrize(
+    "ignore_resource_links, all_databases_and_tables_result",
+    [
+        (True, ({}, [])),
+        (False, ({"test-database": resource_link_database}, target_database_tables)),
+    ],
+)
+def test_ignore_resource_links(ignore_resource_links, all_databases_and_tables_result):
+    source = GlueSource(
+        ctx=PipelineContext(run_id="glue-source-test"),
+        config=GlueSourceConfig(
+            aws_region="eu-west-1",
+            ignore_resource_links=ignore_resource_links,
+        ),
+    )
+
+    with Stubber(source.glue_client) as glue_stubber:
+        glue_stubber.add_response(
+            "get_databases",
+            get_databases_response_with_resource_link,
+            {},
+        )
+        glue_stubber.add_response(
+            "get_tables",
+            get_tables_response_for_target_database,
+            {"DatabaseName": "test-database"},
+        )
+
+        assert source.get_all_databases_and_tables() == all_databases_and_tables_result
+
+
 def test_underlying_platform_must_be_valid():
     with pytest.raises(ConfigurationError):
         GlueSource(
@@ -278,11 +313,11 @@ def test_glue_stateful(pytestconfig, tmp_path, mock_time, mock_datahub_graph):
     ) as mock_checkpoint:
         mock_checkpoint.return_value = mock_datahub_graph
         with patch(
-            "datahub.ingestion.source.aws.glue.GlueSource.get_all_tables_and_databases",
-        ) as mock_get_all_tables_and_databases:
+            "datahub.ingestion.source.aws.glue.GlueSource.get_all_databases_and_tables",
+        ) as mock_get_all_databases_and_tables:
             tables_on_first_call = tables_1
             tables_on_second_call = tables_2
-            mock_get_all_tables_and_databases.side_effect = [
+            mock_get_all_databases_and_tables.side_effect = [
                 (databases_1, tables_on_first_call),
                 (databases_2, tables_on_second_call),
             ]

--- a/metadata-ingestion/tests/unit/test_glue_source_stubs.py
+++ b/metadata-ingestion/tests/unit/test_glue_source_stubs.py
@@ -4,6 +4,49 @@ from typing import Any, Dict
 
 from botocore.response import StreamingBody
 
+resource_link_database = {
+    "Name": "test-database",
+    "CreateTime": datetime.datetime(2021, 6, 9, 14, 14, 19),
+    "CreateTableDefaultPermissions": [],
+    "TargetDatabase": {"CatalogId": "432143214321", "DatabaseName": "test-database"},
+    "CatalogId": "123412341234",
+}
+get_databases_response_with_resource_link = {"DatabaseList": [resource_link_database]}
+
+target_database_tables = [
+    {
+        "Name": "transactions",
+        "DatabaseName": "test-database",
+        "CreateTime": datetime.datetime(2021, 6, 9, 14, 14, 19),
+        "UpdateTime": datetime.datetime(2021, 6, 9, 14, 14, 19),
+        "Retention": 0,
+        "StorageDescriptor": {
+            "Columns": [
+                {"Name": "id", "Type": "bigint", "Comment": ""},
+                {"Name": "name", "Type": "string", "Comment": ""},
+            ],
+            "Location": "s3://test-db-432143214321/transactions",
+            "InputFormat": "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat",
+            "OutputFormat": "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat",
+            "Compressed": False,
+            "NumberOfBuckets": 0,
+            "SerdeInfo": {
+                "Parameters": {"serialization.format": "1"},
+                "SerializationLibrary": "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe",
+            },
+            "SortColumns": [],
+            "StoredAsSubDirectories": False,
+        },
+        "TableType": "EXTERNAL_TABLE",
+        "Parameters": {"classification": "parquet"},
+        "CreatedBy": "arn:aws:sts::432143214321:assumed-role/AWSGlueServiceRole/GlueJobRunnerSession",
+        "IsRegisteredWithLakeFormation": False,
+        "CatalogId": "432143214321",
+        "VersionId": "504",
+    }
+]
+get_tables_response_for_target_database = {"TableList": target_database_tables}
+
 get_databases_response = {
     "DatabaseList": [
         {


### PR DESCRIPTION
## Description


This PR adds a config option to the Glue recipe to detect when database is actually a resource link and automatically filter it out.

The `get_all_tables_and_databases()` method has also been refactored (and renamed) so that the boto3 calls are in their own methods.

## Context

There are at least 2 ways of sharing Glue databases across accounts:
- external catalog sharing
- resource linking - the resource link may have a different name to the original database

If

1. a database is shared via both methods
2. the resource link has a different name to the original database
3. the Glue recipe filter allows for both of them

then a KeyError is thrown. An example is shown in this Slack thread: https://datahubspace.slack.com/archives/CUMUWQU66/p1674044495369769.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
