### PR TITLE
Add platform_instance to browse path for Tableau source and linting

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/confluent_schema_registry.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluent_schema_registry.py
@@ -5,7 +5,6 @@ from hashlib import md5
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 import avro.schema
-import confluent_kafka
 import jsonref
 from confluent_kafka.schema_registry.schema_registry_client import (
     RegisteredSchema,

--- a/metadata-ingestion/src/datahub/ingestion/source/confluent_schema_registry.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluent_schema_registry.py
@@ -420,7 +420,9 @@ class ConfluentSchemaRegistry(KafkaSchemaRegistryBase):
                     platform=platform_urn,
                     platformSchema=KafkaSchema(
                         documentSchema=schema.schema_str if schema is not None else "",
+                        documentSchemaType=schema.schema_type if schema else None,
                         keySchema=key_schema.schema_str if key_schema else None,
+                        keySchemaType=key_schema.schema_type if key_schema else None,
                     ),
                     fields=key_fields + fields,
                 )

--- a/metadata-ingestion/src/datahub/ingestion/source/identity/okta.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/identity/okta.py
@@ -59,15 +59,9 @@ class OktaConfig(StatefulIngestionConfigBase, ConfigModel):
         description="The location of your Okta Domain, without a protocol. Can be found in Okta Developer console. e.g. dev-33231928.okta.com",
     )
     # Require: JWKS configuration for authentication
-    okta_private_key: str = Field(
-        description="Private RSA key"
-    )
-    okta_client_id: str = Field(
-        description="Client ID for the OAuth 2.0 token"
-    )
-    okta_kid: str = Field(
-        description="Key ID for the private RSA key"
-    )
+    okta_private_key: str = Field(description="Private RSA key")
+    okta_client_id: str = Field(description="Client ID for the OAuth 2.0 token")
+    okta_kid: str = Field(description="Key ID for the private RSA key")
 
     # Optional: Whether to ingest users, groups, or both.
     ingest_users: bool = Field(
@@ -420,12 +414,12 @@ class OktaSource(StatefulIngestionSourceBase):
     # Instantiates Okta SDK Client.
     def _create_okta_client(self):
         config = {
-            'orgUrl': f"https://{self.config.okta_domain}",
-            'authorizationMode': 'PrivateKey',
-            'clientId': f'{self.config.okta_client_id}',
-            'scopes': ['okta.users.read', 'okta.groups.read'],
-            'kid': f'{self.config.okta_kid}',
-            'privateKey': f'{self.config.okta_private_key}',
+            "orgUrl": f"https://{self.config.okta_domain}",
+            "authorizationMode": "PrivateKey",
+            "clientId": f"{self.config.okta_client_id}",
+            "scopes": ["okta.users.read", "okta.groups.read"],
+            "kid": f"{self.config.okta_kid}",
+            "privateKey": f"{self.config.okta_private_key}",
             "raiseException": True,
         }
         return OktaClient(config)

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka.py
@@ -55,7 +55,6 @@ from datahub.metadata.schema_classes import (
     BrowsePathsClass,
     DataPlatformInstanceClass,
     DatasetPropertiesClass,
-    KafkaSchemaClass,
     SubTypesClass,
 )
 from datahub.utilities.registries.domain_registry import DomainRegistry
@@ -244,9 +243,6 @@ class KafkaSource(StatefulIngestionSourceBase):
         extra_topic_config: Optional[Dict[str, ConfigEntry]],
     ) -> Iterable[MetadataWorkUnit]:
         logger.debug(f"topic = {topic}")
-
-        AVRO = "AVRO"
-        DOC_KEY = "doc"
 
         # 1. Create the default dataset snapshot for the topic.
         dataset_name = topic

--- a/metadata-ingestion/src/datahub/ingestion/source/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau.py
@@ -1181,7 +1181,13 @@ class TableauSource(StatefulIngestionSourceBase):
             if project and datasource_name:
                 browse_paths = BrowsePathsClass(
                     paths=[
-                        f"/{self.config.env.lower()}/{self.platform}/{project}/{datasource[tableau_constant.NAME]}"
+                        f"/{self.config.env.lower()}/{self.platform}"
+                        + (
+                            f"/{self.config.platform_instance}"
+                            if self.config.platform_instance
+                            else ""
+                        )
+                        + f"/{project}/{datasource[tableau_constant.NAME]}"
                     ]
                 )
                 dataset_snapshot.aspects.append(browse_paths)
@@ -1487,7 +1493,15 @@ class TableauSource(StatefulIngestionSourceBase):
 
         if browse_path:
             browse_paths = BrowsePathsClass(
-                paths=[f"/{self.config.env.lower()}/{self.platform}/{browse_path}"]
+                paths=[
+                    f"/{self.config.env.lower()}/{self.platform}"
+                    + (
+                        f"/{self.config.platform_instance}"
+                        if self.config.platform_instance
+                        else ""
+                    )
+                    + f"/{browse_path}"
+                ]
             )
             dataset_snapshot.aspects.append(browse_paths)
 
@@ -1628,7 +1642,15 @@ class TableauSource(StatefulIngestionSourceBase):
             if browse_path:
                 # Browse path
                 browse_paths = BrowsePathsClass(
-                    paths=[f"/{self.config.env.lower()}/{self.platform}/{browse_path}"]
+                    paths=[
+                        f"/{self.config.env.lower()}/{self.platform}"
+                        + (
+                            f"/{self.config.platform_instance}"
+                            if self.config.platform_instance
+                            else ""
+                        )
+                        + f"/{browse_path}"
+                    ]
                 )
                 dataset_snapshot.aspects.append(browse_paths)
             else:
@@ -1814,8 +1836,14 @@ class TableauSource(StatefulIngestionSourceBase):
         ):
             browse_paths = BrowsePathsClass(
                 paths=[
-                    f"/{self.platform}/{self._project_luid_to_browse_path_name(project_luid)}"
-                    f"/{workbook[tableau_constant.NAME].replace('/', REPLACE_SLASH_CHAR)}"
+                    f"/{self.platform}"
+                    + (
+                        f"/{self.config.platform_instance}"
+                        if self.config.platform_instance
+                        else ""
+                    )
+                    + f"/{self._project_luid_to_browse_path_name(project_luid)}"
+                    + f"/{workbook[tableau_constant.NAME].replace('/', REPLACE_SLASH_CHAR)}"
                 ]
             )
             chart_snapshot.aspects.append(browse_paths)
@@ -2117,8 +2145,14 @@ class TableauSource(StatefulIngestionSourceBase):
         ):
             browse_paths = BrowsePathsClass(
                 paths=[
-                    f"/{self.platform}/{self._project_luid_to_browse_path_name(project_luid)}"
-                    f"/{workbook[tableau_constant.NAME].replace('/', REPLACE_SLASH_CHAR)}"
+                    f"/{self.platform}"
+                    + (
+                        f"/{self.config.platform_instance}"
+                        if self.config.platform_instance
+                        else ""
+                    )
+                    + f"/{self._project_luid_to_browse_path_name(project_luid)}"
+                    + f"/{workbook[tableau_constant.NAME].replace('/', REPLACE_SLASH_CHAR)}"
                 ]
             )
             dashboard_snapshot.aspects.append(browse_paths)
@@ -2130,8 +2164,14 @@ class TableauSource(StatefulIngestionSourceBase):
             # browse path
             browse_paths = BrowsePathsClass(
                 paths=[
-                    f"/{self.platform}/{workbook[tableau_constant.PROJECT_NAME].replace('/', REPLACE_SLASH_CHAR)}"
-                    f"/{workbook[tableau_constant.NAME].replace('/', REPLACE_SLASH_CHAR)}"
+                    f"/{self.platform}"
+                    + (
+                        f"/{self.config.platform_instance}"
+                        if self.config.platform_instance
+                        else ""
+                    )
+                    + f"/{workbook[tableau_constant.PROJECT_NAME].replace('/', REPLACE_SLASH_CHAR)}"
+                    + f"/{workbook[tableau_constant.NAME].replace('/', REPLACE_SLASH_CHAR)}"
                 ]
             )
             dashboard_snapshot.aspects.append(browse_paths)

--- a/metadata-ingestion/src/datahub/utilities/mapping.py
+++ b/metadata-ingestion/src/datahub/utilities/mapping.py
@@ -3,9 +3,10 @@ import logging
 import operator
 import re
 from functools import reduce
+from typing import Any, Dict, List, Match, Optional, Union
+
 from jinja2 import Template
 from jinja2.sandbox import SandboxedEnvironment
-from typing import Any, Dict, List, Match, Optional, Union
 
 from datahub.emitter import mce_builder
 from datahub.emitter.mce_builder import OwnerType
@@ -38,8 +39,9 @@ def _insert_match_value(original_value: str, match_value: str) -> str:
     e.g. "foo<match_value>bar". Otherwise, it will leave the original value unchanged.
     Uses a Jinja2 template render to perform simple string operations.
     """
-    return Template(_match_regexp.sub(match_value, original_value)).render(jinja_env=SandboxedEnvironment())
-
+    return Template(_match_regexp.sub(match_value, original_value)).render(
+        jinja_env=SandboxedEnvironment()
+    )
 
 
 class Constants:
@@ -271,7 +273,9 @@ class OperationProcessor:
         # function to check if a match clause is satisfied to a value.
         if type(raw_props_value) not in Constants.OPERAND_DATATYPE_SUPPORTED:
             return None
-        elif type(raw_props_value) != bool and type(raw_props_value) != type(match_clause):
+        elif type(raw_props_value) != bool and type(raw_props_value) != type(
+            match_clause
+        ):
             return None
         elif type(raw_props_value) == str:
             return re.match(match_clause, raw_props_value)

--- a/metadata-ingestion/tests/integration/okta/okta_mces_golden_custom_user_name_regex.json
+++ b/metadata-ingestion/tests/integration/okta/okta_mces_golden_custom_user_name_regex.json
@@ -106,37 +106,6 @@
     }
 },
 {
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.CorpUserSnapshot": {
-            "urn": "urn:li:corpuser:john.doe@test.com",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.identity.CorpUserInfo": {
-                        "active": true,
-                        "displayName": "JDoe",
-                        "email": "john.doe@test.com",
-                        "firstName": "John",
-                        "lastName": "Doe",
-                        "fullName": "John Doe"
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.identity.GroupMembership": {
-                        "groups": [
-                            "urn:li:corpGroup:All%20Employees",
-                            "urn:li:corpGroup:Engineering"
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1586847600000,
-        "runId": "test-okta-usage"
-    }
-},
-{
     "entityType": "corpuser",
     "entityUrn": "urn:li:corpuser:john.doe@test.com",
     "changeType": "UPSERT",
@@ -174,7 +143,10 @@
             "aspects": [
                 {
                     "com.linkedin.pegasus2avro.identity.CorpUserInfo": {
-                        "active": true,
+                        "customProperties": {
+                            "department": "Engineering"
+                        },
+                        "active": false,
                         "displayName": "Mary Jane",
                         "email": "mary.jane@test.com",
                         "title": "Software Engineer",
@@ -241,7 +213,10 @@
             "aspects": [
                 {
                     "com.linkedin.pegasus2avro.identity.CorpUserInfo": {
-                        "active": true,
+                        "customProperties": {
+                            "department": "Marketing"
+                        },
+                        "active": false,
                         "displayName": "Good Test",
                         "email": "good.test@test.com",
                         "title": "Manager",

--- a/metadata-ingestion/tests/integration/okta/okta_mces_golden_default_config.json
+++ b/metadata-ingestion/tests/integration/okta/okta_mces_golden_default_config.json
@@ -106,37 +106,6 @@
     }
 },
 {
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.CorpUserSnapshot": {
-            "urn": "urn:li:corpuser:john.doe",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.identity.CorpUserInfo": {
-                        "active": true,
-                        "displayName": "JDoe",
-                        "email": "john.doe@test.com",
-                        "firstName": "John",
-                        "lastName": "Doe",
-                        "fullName": "John Doe"
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.identity.GroupMembership": {
-                        "groups": [
-                            "urn:li:corpGroup:All%20Employees",
-                            "urn:li:corpGroup:Engineering"
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1586847600000,
-        "runId": "test-okta-usage"
-    }
-},
-{
     "entityType": "corpuser",
     "entityUrn": "urn:li:corpuser:john.doe",
     "changeType": "UPSERT",
@@ -174,7 +143,10 @@
             "aspects": [
                 {
                     "com.linkedin.pegasus2avro.identity.CorpUserInfo": {
-                        "active": true,
+                        "customProperties": {
+                            "department": "Engineering"
+                        },
+                        "active": false,
                         "displayName": "Mary Jane",
                         "email": "mary.jane@test.com",
                         "title": "Software Engineer",
@@ -241,7 +213,10 @@
             "aspects": [
                 {
                     "com.linkedin.pegasus2avro.identity.CorpUserInfo": {
-                        "active": true,
+                        "customProperties": {
+                            "department": "Marketing"
+                        },
+                        "active": false,
                         "displayName": "Good Test",
                         "email": "good.test@test.com",
                         "title": "Manager",

--- a/metadata-ingestion/tests/integration/okta/okta_mces_golden_include_deprovisioned_suspended_users.json
+++ b/metadata-ingestion/tests/integration/okta/okta_mces_golden_include_deprovisioned_suspended_users.json
@@ -106,37 +106,6 @@
     }
 },
 {
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.CorpUserSnapshot": {
-            "urn": "urn:li:corpuser:john.doe",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.identity.CorpUserInfo": {
-                        "active": true,
-                        "displayName": "JDoe",
-                        "email": "john.doe@test.com",
-                        "firstName": "John",
-                        "lastName": "Doe",
-                        "fullName": "John Doe"
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.identity.GroupMembership": {
-                        "groups": [
-                            "urn:li:corpGroup:All%20Employees",
-                            "urn:li:corpGroup:Engineering"
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1586847600000,
-        "runId": "test-okta-usage"
-    }
-},
-{
     "entityType": "corpuser",
     "entityUrn": "urn:li:corpuser:john.doe",
     "changeType": "UPSERT",
@@ -174,7 +143,10 @@
             "aspects": [
                 {
                     "com.linkedin.pegasus2avro.identity.CorpUserInfo": {
-                        "active": true,
+                        "customProperties": {
+                            "department": "Engineering"
+                        },
+                        "active": false,
                         "displayName": "Mary Jane",
                         "email": "mary.jane@test.com",
                         "title": "Software Engineer",
@@ -241,7 +213,10 @@
             "aspects": [
                 {
                     "com.linkedin.pegasus2avro.identity.CorpUserInfo": {
-                        "active": true,
+                        "customProperties": {
+                            "department": "Marketing"
+                        },
+                        "active": false,
                         "displayName": "Good Test",
                         "email": "good.test@test.com",
                         "title": "Manager",
@@ -303,7 +278,10 @@
             "aspects": [
                 {
                     "com.linkedin.pegasus2avro.identity.CorpUserInfo": {
-                        "active": true,
+                        "customProperties": {
+                            "department": "Engineering"
+                        },
+                        "active": false,
                         "displayName": "Mary Jane",
                         "email": "mary.jane@test.com",
                         "title": "Software Engineer II",
@@ -364,37 +342,6 @@
     }
 },
 {
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.CorpUserSnapshot": {
-            "urn": "urn:li:corpuser:bad.boyjones",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.identity.CorpUserInfo": {
-                        "active": true,
-                        "displayName": "Bad Boy Jones",
-                        "email": "bad.boyjones@test.com",
-                        "firstName": "Bad",
-                        "lastName": "Boy Jones",
-                        "fullName": "Bad Boy Jones"
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.identity.GroupMembership": {
-                        "groups": [
-                            "urn:li:corpGroup:All%20Employees",
-                            "urn:li:corpGroup:Engineering"
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1586847600000,
-        "runId": "test-okta-usage"
-    }
-},
-{
     "entityType": "corpuser",
     "entityUrn": "urn:li:corpuser:bad.boyjones",
     "changeType": "UPSERT",
@@ -432,7 +379,10 @@
             "aspects": [
                 {
                     "com.linkedin.pegasus2avro.identity.CorpUserInfo": {
-                        "active": true,
+                        "customProperties": {
+                            "department": "Marketing"
+                        },
+                        "active": false,
                         "displayName": "Bad Girl Riri",
                         "email": "bad.girlriri@test.com",
                         "title": "Manager",

--- a/metadata-ingestion/tests/integration/okta/test_okta.py
+++ b/metadata-ingestion/tests/integration/okta/test_okta.py
@@ -30,7 +30,9 @@ def default_recipe(output_file_path):
             "type": "okta",
             "config": {
                 "okta_domain": "mock-domain.okta.com",
-                "okta_api_token": "mock-okta-token",
+                "okta_private_key": "mock-okta-private-key",
+                "okta_client_id": "mock-okta-client-id",
+                "okta_kid": "mock-okta-kid",
                 "ingest_users": "True",
                 "ingest_groups": "True",
                 "ingest_group_membership": "True",
@@ -80,12 +82,19 @@ def run_ingest(
 
 def test_okta_config():
     config = OktaConfig.parse_obj(
-        dict(okta_domain="test.okta.com", okta_api_token="test-token")
+        dict(
+            okta_domain="test.okta.com",
+            okta_private_key="mock-okta-private-key",
+            okta_client_id="mock-okta-client-id",
+            okta_kid="mock-okta-kid",
+        )
     )
 
     # Sanity on required configurations
     assert config.okta_domain == "test.okta.com"
-    assert config.okta_api_token == "test-token"
+    assert config.okta_private_key == "mock-okta-private-key"
+    assert config.okta_client_id == "mock-okta-client-id"
+    assert config.okta_kid == "mock-okta-kid"
 
     # Assert on default configurations
     assert config.ingest_users is True

--- a/metadata-ingestion/tests/unit/test_confluent_schema_registry.py
+++ b/metadata-ingestion/tests/unit/test_confluent_schema_registry.py
@@ -168,7 +168,7 @@ class ConfluentSchemaRegistryTest(unittest.TestCase):
             )
 
     @patch(
-        "datahub.ingestion.source.confluent_schema_registry.confluent_kafka.schema_registry.schema_registry_client.SchemaRegistryClient",
+        "datahub.ingestion.source.confluent_schema_registry.SchemaRegistryClient",
         autospec=True,
     )
     def test_get_aspects_from_schema_avro(self, mock_schema_registry_client):


### PR DESCRIPTION
## Description

Adding platform_instance to the browse path for tableau entities. Also did some linting and fixed some outdated tests.
Note: golden test files are autogenerated so no need to review that. Tests for those are passing.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
