### PR TITLE
[GDP-1643] Add support for Athena lineage in tableau from custom SQL

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau.py
@@ -327,9 +327,9 @@ class TableauConfig(
         description="[Experimental] Whether to extract lineage from unsupported custom sql queries using SQL parsing",
     )
 
-    region_prefix: str = Field(
+    lineage_platform_instance: str = Field(
         default="uk",
-        description="AWS region prefix for mapping Athena table URNs.",
+        description="Platform prefix for mapping upstream lineage URNs.",
     )
 
     # pre = True because we want to take some decision before pydantic initialize the configuration to default values
@@ -1396,7 +1396,7 @@ class TableauSource(StatefulIngestionSourceBase):
                             full_name=split_table[1],
                             platform_instance_map=self.config.platform_instance_map,
                             lineage_overrides=self.config.lineage_overrides,
-                            region_prefix=self.config.region_prefix
+                            lineage_platform_instance=self.config.lineage_platform_instance
                         )
                         upstream_tables.append(
                             UpstreamClass(

--- a/metadata-ingestion/src/datahub/ingestion/source/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau.py
@@ -327,6 +327,11 @@ class TableauConfig(
         description="[Experimental] Whether to extract lineage from unsupported custom sql queries using SQL parsing",
     )
 
+    region_prefix: str = Field(
+        default="uk",
+        description="AWS region prefix for mapping Athena table URNs.",
+    )
+
     # pre = True because we want to take some decision before pydantic initialize the configuration to default values
     @root_validator(pre=True)
     def projects_backward_compatibility(cls, values: Dict) -> Dict:
@@ -1369,9 +1374,14 @@ class TableauSource(StatefulIngestionSourceBase):
             and tableau_constant.CONNECTION_TYPE in database
         ):
             upstream_tables = []
-            query = csql.get(tableau_constant.QUERY)
-            parser = LineageRunner(query)
+            # Clean query as for some reason some queries are read in with duplicated </> characters
+            query = clean_query(csql.get(tableau_constant.QUERY))
 
+            # suppress sqlfluff logging because it is very spammy and lags the Airflow UI
+            logging.getLogger('sqlfluff.parser').setLevel(logging.WARNING)
+            logging.getLogger('sqlfluff.linter').setLevel(logging.WARNING)
+
+            parser = LineageRunner(query)
             try:
                 for table in parser.source_tables:
                     split_table = str(table).split(".")
@@ -1386,6 +1396,7 @@ class TableauSource(StatefulIngestionSourceBase):
                             full_name=split_table[1],
                             platform_instance_map=self.config.platform_instance_map,
                             lineage_overrides=self.config.lineage_overrides,
+                            region_prefix=self.config.region_prefix
                         )
                         upstream_tables.append(
                             UpstreamClass(

--- a/metadata-ingestion/src/datahub/ingestion/source/tableau_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau_common.py
@@ -527,7 +527,7 @@ def get_fully_qualified_table_name(
     upstream_db: str,
     schema: str,
     full_name: str,
-    region_prefix: Optional[str] = None,
+    lineage_platform_instance: Optional[str] = None,
 ) -> str:
     if platform == "athena":
         upstream_db = ""
@@ -560,8 +560,8 @@ def get_fully_qualified_table_name(
             fully_qualified_table_name.split(".")[-3:]
         )
 
-    if region_prefix:
-        fully_qualified_table_name = f"{region_prefix}.{fully_qualified_table_name}"
+    if lineage_platform_instance:
+        fully_qualified_table_name = f"{lineage_platform_instance}.{fully_qualified_table_name}"
 
     return fully_qualified_table_name
 
@@ -583,7 +583,7 @@ def make_table_urn(
     full_name: str,
     platform_instance_map: Optional[Dict[str, str]],
     lineage_overrides: Optional[TableauLineageOverrides] = None,
-    region_prefix: Optional[str] = None,
+    lineage_platform_instance: Optional[str] = None,
 ) -> str:
     original_platform = platform = get_platform(connection_type)
     if (
@@ -602,7 +602,7 @@ def make_table_urn(
         upstream_db = lineage_overrides.database_override_map[upstream_db]
 
     table_name = get_fully_qualified_table_name(
-        original_platform, upstream_db, schema, full_name, region_prefix
+        original_platform, upstream_db, schema, full_name, lineage_platform_instance
     )
     platform_instance = get_platform_instance(original_platform, platform_instance_map)
     return builder.make_dataset_urn_with_platform_instance(

--- a/metadata-ingestion/src/datahub/ingestion/source/tableau_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau_common.py
@@ -527,6 +527,7 @@ def get_fully_qualified_table_name(
     upstream_db: str,
     schema: str,
     full_name: str,
+    region_prefix: Optional[str] = None,
 ) -> str:
     if platform == "athena":
         upstream_db = ""
@@ -559,6 +560,9 @@ def get_fully_qualified_table_name(
             fully_qualified_table_name.split(".")[-3:]
         )
 
+    if region_prefix:
+        fully_qualified_table_name = f"{region_prefix}.{fully_qualified_table_name}"
+
     return fully_qualified_table_name
 
 
@@ -579,6 +583,7 @@ def make_table_urn(
     full_name: str,
     platform_instance_map: Optional[Dict[str, str]],
     lineage_overrides: Optional[TableauLineageOverrides] = None,
+    region_prefix: Optional[str] = None,
 ) -> str:
     original_platform = platform = get_platform(connection_type)
     if (
@@ -597,7 +602,7 @@ def make_table_urn(
         upstream_db = lineage_overrides.database_override_map[upstream_db]
 
     table_name = get_fully_qualified_table_name(
-        original_platform, upstream_db, schema, full_name
+        original_platform, upstream_db, schema, full_name, region_prefix
     )
     platform_instance = get_platform_instance(original_platform, platform_instance_map)
     return builder.make_dataset_urn_with_platform_instance(


### PR DESCRIPTION
Adds support for upstream lineage from Tableau Custom SQL to Athena tables. The main modification made to support this is passing an athena region through to the tableau ingestion, so we can determine the correct upstream table URN (e.g. `urn:li:dataset:(urn:li:dataPlatform:athena,us.events_production.chargeback_sanitized,PROD)`

Not all queries parse correctly, and it seems that using the `athena` dialect in the parser causes more parsing issues than it solves.

Tested in Staging for US and UK Tableau Custom SQL.