### PR TITLE
[GDP-1766] Add departmentName to identify calls

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -64,6 +64,17 @@ steps:
       ENVIRONMENT: production
       AMPLITUDE_API_KEY: f0b9cf5c530426c3dbacb91e74f009a5
 
+  # Push the staging image, tagged with the branch name. Useful for testing the image in fc-datahub.
+  - name: docker_frontend_development
+    <<: *docker_build_config
+    settings:
+      context : /drone/src/staging/
+      dockerfile: /drone/src/staging/docker/datahub-frontend/Dockerfile
+      tags:
+        - ${DRONE_BRANCH//\//-}
+    depends_on:
+      - build_frontend_staging
+
   - name: docker_frontend_staging
     <<: *docker_build_config
     <<: *when_internal_branch

--- a/datahub-web-react/src/graphql/me.graphql
+++ b/datahub-web-react/src/graphql/me.graphql
@@ -11,6 +11,7 @@ query getMe {
                 lastName
                 fullName
                 email
+                departmentName
             }
             editableProperties {
                 displayName


### PR DESCRIPTION
Adds the departmentName to identify calls, so we can segment in Amplitude by people's teams.

Also set drone up to push/tag the image with the branch name for testing purposes

Tested by building/deploying into staging

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
