### PR TITLE
[GDP-1902]

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau.py
@@ -506,6 +506,9 @@ class TableauSource(StatefulIngestionSourceBase):
                 x.strip()
                 for x in (self.config.ignore_upstream_lineage_platforms.split(","))
             ]
+        else:
+            # return empty list if the config is not set
+            self.ignore_upstream_lineage_platforms = []
 
         self._authenticate()
 

--- a/metadata-ingestion/src/datahub/ingestion/source/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau.py
@@ -1043,7 +1043,7 @@ class TableauSource(StatefulIngestionSourceBase):
 
             # skip upstream tables if the source is postgres and the database is not whitelisted
             if table.get(tableau_constant.CONNECTION_TYPE) == "postgres":
-                upstream_db = table.get([tableau_constant.DATABASE], {}).get([tableau_constant.NAME], "")
+                upstream_db = table.get(tableau_constant.DATABASE, {}).get(tableau_constant.NAME, "")
                 if (
                     upstream_db
                     and upstream_db not in self.upstream_postgres_database_whitelist

--- a/metadata-ingestion/src/datahub/ingestion/source/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau.py
@@ -516,18 +516,18 @@ class TableauSource(StatefulIngestionSourceBase):
             self.ignore_upstream_lineage_platforms = []
 
         # if ignore upstream lineage platforms doesn't contain "postgres", then consult the upstream_postgres_database_whitelist
-        if "postgres" not in self.ignore_upstream_lineage_platforms:
-            if self.config.upstream_postgres_database_whitelist:
-                self.upstream_postgres_database_whitelist = [
-                    x.strip()
-                    for x in (
-                        self.config.upstream_postgres_database_whitelist.split(",")
-                    )
-                ]
-            else:
-                # return empty list if the config is not set
-                self.upstream_postgres_database_whitelist = []
+        if (
+            "postgres" not in self.ignore_upstream_lineage_platforms 
+            and self.config.upstream_postgres_database_whitelist
+        ):
+            self.upstream_postgres_database_whitelist = [
+                x.strip()
+                for x in (
+                    self.config.upstream_postgres_database_whitelist.split(",")
+                )
+            ]
         else:
+            # return empty list if the config is not set
             self.upstream_postgres_database_whitelist = []
         
 
@@ -1043,12 +1043,7 @@ class TableauSource(StatefulIngestionSourceBase):
 
             # skip upstream tables if the source is postgres and the database is not whitelisted
             if table.get(tableau_constant.CONNECTION_TYPE) == "postgres":
-                upstream_db = (
-                    table[tableau_constant.DATABASE][tableau_constant.NAME]
-                    if table.get(tableau_constant.DATABASE)
-                    and table[tableau_constant.DATABASE].get(tableau_constant.NAME)
-                    else ""
-                )
+                upstream_db = table.get([tableau_constant.DATABASE], {}).get([tableau_constant.NAME], "")
                 if (
                     upstream_db
                     and upstream_db not in self.upstream_postgres_database_whitelist

--- a/metadata-ingestion/src/datahub/ingestion/source/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau.py
@@ -364,6 +364,11 @@ class TableauConfig(
         description="Comma separated list of platforms to not ingest upstream lineage for",
     )
 
+    upstream_postgres_database_whitelist: Optional[str] = Field(
+        default="",
+        description="Comma separated list of postgres databases to include in upstream lineage",
+    )
+
     # pre = True because we want to take some decision before pydantic initialize the configuration to default values
     @root_validator(pre=True)
     def projects_backward_compatibility(cls, values: Dict) -> Dict:
@@ -509,6 +514,22 @@ class TableauSource(StatefulIngestionSourceBase):
         else:
             # return empty list if the config is not set
             self.ignore_upstream_lineage_platforms = []
+
+        # if ignore upstream lineage platforms doesn't contain "postgres", then consult the upstream_postgres_database_whitelist
+        if "postgres" not in self.ignore_upstream_lineage_platforms:
+            if self.config.upstream_postgres_database_whitelist:
+                self.upstream_postgres_database_whitelist = [
+                    x.strip()
+                    for x in (
+                        self.config.upstream_postgres_database_whitelist.split(",")
+                    )
+                ]
+            else:
+                # return empty list if the config is not set
+                self.upstream_postgres_database_whitelist = []
+        else:
+            self.upstream_postgres_database_whitelist = []
+        
 
         self._authenticate()
 
@@ -1019,6 +1040,24 @@ class TableauSource(StatefulIngestionSourceBase):
                     f"Skipping upstream table {table[tableau_constant.ID]} from lineage since its name is none: {table}"
                 )
                 continue
+
+            # skip upstream tables if the source is postgres and the database is not whitelisted
+            if table.get(tableau_constant.CONNECTION_TYPE) == "postgres":
+                upstream_db = (
+                    table[tableau_constant.DATABASE][tableau_constant.NAME]
+                    if table.get(tableau_constant.DATABASE)
+                    and table[tableau_constant.DATABASE].get(tableau_constant.NAME)
+                    else ""
+                )
+                if (
+                    upstream_db
+                    and upstream_db not in self.upstream_postgres_database_whitelist
+                ):
+                    logger.debug(
+                        f"Skipping upstream table {table[tableau_constant.ID]}, database {upstream_db} not whitelisted"
+                    )
+                    continue
+
 
             schema = table.get(tableau_constant.SCHEMA) or ""
             table_name = table.get(tableau_constant.NAME) or ""

--- a/metadata-ingestion/tests/integration/tableau/tableau_cll_mces_golden.json
+++ b/metadata-ingestion/tests/integration/tableau/tableau_cll_mces_golden.json
@@ -10704,6 +10704,18 @@
                     }
                 },
                 {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            }
+                        ]
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.common.Ownership": {
                         "owners": [
                             {
@@ -12510,30 +12522,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,801c95e3-b07e-7bfe-3789-a561c7beccd3,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:008e111aa1d250dd52e0fd5d4b307b1a",
-                    "urn": "urn:li:container:008e111aa1d250dd52e0fd5d4b307b1a"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,4644ccb1-2adc-cf26-c654-04ed1dcc7090,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -12545,7 +12533,7 @@
                         "time": 0,
                         "actor": "urn:li:corpuser:unknown"
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,10c6297d-0dbd-44f1-b1ba-458bea446513,PROD)",
                     "type": "TRANSFORMED"
                 },
                 {
@@ -12553,7 +12541,7 @@
                         "time": 0,
                         "actor": "urn:li:corpuser:unknown"
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,10c6297d-0dbd-44f1-b1ba-458bea446513,PROD)",
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
                     "type": "TRANSFORMED"
                 }
             ],
@@ -12646,6 +12634,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
                         ]
                     }
                 },
@@ -12908,30 +12908,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,4644ccb1-2adc-cf26-c654-04ed1dcc7090,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1",
-                    "urn": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,618c87db-5959-338b-bcc7-6f5f4cc0b6c6,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -12976,6 +12952,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
                         ]
                     }
                 },
@@ -13401,30 +13389,6 @@
     "aspect": {
         "json": {
             "container": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,618c87db-5959-338b-bcc7-6f5f4cc0b6c6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1",
-                    "urn": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-                }
-            ]
         }
     },
     "systemMetadata": {
@@ -13880,6 +13844,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
                         ]
                     }
                 },
@@ -14649,30 +14625,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,d00f4ba6-707e-4684-20af-69eb47587cc2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1",
-                    "urn": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,06c3e060-8133-4b58-9b53-a0fced25e056,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -14830,6 +14782,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            }
                         ]
                     }
                 },
@@ -21467,30 +21431,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,06c3e060-8133-4b58-9b53-a0fced25e056,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d",
-                    "urn": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,3ade7817-ae27-259e-8e48-1570e7f932f6,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -21691,6 +21631,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            }
                         ]
                     }
                 },
@@ -25614,30 +25566,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,3ade7817-ae27-259e-8e48-1570e7f932f6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d",
-                    "urn": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,dfe2c02a-54b7-f7a2-39fc-c651da2f6ad8,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -25800,6 +25728,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            }
                         ]
                     }
                 },
@@ -30985,30 +30925,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,dfe2c02a-54b7-f7a2-39fc-c651da2f6ad8,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d",
-                    "urn": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,d8d4c0ea-3162-fa11-31e6-26675da44a38,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -31143,6 +31059,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Workbook published ds"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Workbook published ds"
+                            }
                         ]
                     }
                 },
@@ -31392,30 +31320,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,d8d4c0ea-3162-fa11-31e6-26675da44a38,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:94e6e84b66f9ee8c70c22f06cfbad6a9",
-                    "urn": "urn:li:container:94e6e84b66f9ee8c70c22f06cfbad6a9"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,00cce29f-b561-bb41-3557-8e19660bb5dd,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -31531,6 +31435,15 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            }
                         ]
                     }
                 },
@@ -31826,26 +31739,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,00cce29f-b561-bb41-3557-8e19660bb5dd,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,6cbbeeb2-9f3a-00f6-2342-17139d6e97ae,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -31991,6 +31884,15 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/Samples"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "Samples"
+                            }
                         ]
                     }
                 },
@@ -32890,26 +32792,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,6cbbeeb2-9f3a-00f6-2342-17139d6e97ae,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:d2dcd6bd1bb954d62f1cfc68332ee873",
-                    "urn": "urn:li:container:d2dcd6bd1bb954d62f1cfc68332ee873"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
@@ -33068,6 +32950,18 @@
                     }
                 },
                 {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
+                        ]
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {},
                         "name": "Custom SQL Query",
@@ -33099,30 +32993,6 @@
             "typeNames": [
                 "View",
                 "Custom SQL"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1",
-                    "urn": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-                }
             ]
         }
     },
@@ -33296,6 +33166,15 @@
                     }
                 },
                 {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            }
+                        ]
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {},
                         "name": "Custom SQL Query",
@@ -33327,28 +33206,6 @@
             "typeNames": [
                 "View",
                 "Custom SQL"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,4fb670d5-3e19-9656-e684-74aa9729cf18,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "test publish datasource"
-                }
             ]
         }
     },
@@ -33474,6 +33331,15 @@
                     }
                 },
                 {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "SubProject1"
+                            }
+                        ]
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {},
                         "name": "Custom SQL Query",
@@ -33514,28 +33380,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,10c6297d-0dbd-44f1-b1ba-458bea446513,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "SubProject1"
-                },
-                {
-                    "id": "AbcJoinWorkbook"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity6,PROD)",
@@ -33544,6 +33388,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -33699,31 +33558,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity11,PROD)",
@@ -33732,6 +33566,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -33959,31 +33808,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity11,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity10,PROD)",
@@ -33992,6 +33816,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -34195,31 +34034,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity10,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity7,PROD)",
@@ -34228,6 +34042,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -34383,31 +34212,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity7,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.campaignstable,PROD)",
@@ -34416,6 +34220,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -34559,31 +34378,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.campaignstable,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.address,PROD)",
@@ -34592,6 +34386,25 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook/actor+ (dvdrental)"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            },
+                            {
+                                "id": "actor+ (dvdrental)"
+                            }
                         ]
                     }
                 },
@@ -34723,31 +34536,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Dvdrental Workbook"
-                },
-                {
-                    "id": "actor+ (dvdrental)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.actor,PROD)",
@@ -34756,6 +34544,25 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook/actor+ (dvdrental)"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            },
+                            {
+                                "id": "actor+ (dvdrental)"
+                            }
                         ]
                     }
                 },
@@ -34839,31 +34646,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Dvdrental Workbook"
-                },
-                {
-                    "id": "actor+ (dvdrental)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.people,PROD)",
@@ -34872,6 +34654,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/Samples/Superstore Datasource"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "Samples"
+                            },
+                            {
+                                "id": "Superstore Datasource"
+                            }
                         ]
                     }
                 },
@@ -34931,28 +34725,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.people,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "Samples"
-                },
-                {
-                    "id": "Superstore Datasource"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.returns,PROD)",
@@ -34961,6 +34733,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/Samples/Superstore Datasource"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "Samples"
+                            },
+                            {
+                                "id": "Superstore Datasource"
+                            }
                         ]
                     }
                 },
@@ -35020,28 +34804,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.returns,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "Samples"
-                },
-                {
-                    "id": "Superstore Datasource"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.orders,PROD)",
@@ -35050,6 +34812,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/Samples/Superstore Datasource"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "Samples"
+                            },
+                            {
+                                "id": "Superstore Datasource"
+                            }
                         ]
                     }
                 },
@@ -35337,28 +35111,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.orders,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "Samples"
-                },
-                {
-                    "id": "Superstore Datasource"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.task,PROD)",
@@ -35369,6 +35121,21 @@
                             "/prod/tableau/default/Executive Dashboard/Problems",
                             "/prod/tableau/default/Executive Dashboard/Requests",
                             "/prod/tableau/default/Executive Dashboard/Incidents"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Incidents"
+                            }
                         ]
                     }
                 },
@@ -36148,31 +35915,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.task,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Problems"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_request,PROD)",
@@ -36181,6 +35923,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Requests"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Requests"
+                            }
                         ]
                     }
                 },
@@ -37056,31 +36813,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_request,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Requests"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_req_item,PROD)",
@@ -37089,6 +36821,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Requests"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Requests"
+                            }
                         ]
                     }
                 },
@@ -38036,31 +37783,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_req_item,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Requests"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_cat_item,PROD)",
@@ -38069,6 +37791,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Requests"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Requests"
+                            }
                         ]
                     }
                 },
@@ -38884,31 +38621,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_cat_item,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Requests"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sys_user_group,PROD)",
@@ -38917,6 +38629,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Problems"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Problems"
+                            }
                         ]
                     }
                 },
@@ -39216,31 +38943,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sys_user_group,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Problems"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.problem,PROD)",
@@ -39249,6 +38951,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Problems"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Problems"
+                            }
                         ]
                     }
                 },
@@ -40088,31 +39805,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.problem,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Problems"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.incident,PROD)",
@@ -40121,6 +39813,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Incidents"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Incidents"
+                            }
                         ]
                     }
                 },
@@ -41104,31 +40811,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.incident,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Incidents"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.cmdb_ci,PROD)",
@@ -41137,6 +40819,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Incidents"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Incidents"
+                            }
                         ]
                     }
                 },
@@ -41988,31 +41685,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.cmdb_ci,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Incidents"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.customer,PROD)",
@@ -42024,28 +41696,22 @@
                             "/prod/tableau/default/test publish datasource"
                         ]
                     }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
                 },
                 {
-                    "id": "Customer Payment Query"
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "test publish datasource"
+                            }
+                        ]
+                    }
                 }
             ]
         }
@@ -42067,28 +41733,22 @@
                             "/prod/tableau/default/test publish datasource"
                         ]
                     }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.payment,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
                 },
                 {
-                    "id": "Customer Payment Query"
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "test publish datasource"
+                            }
+                        ]
+                    }
                 }
             ]
         }
@@ -42109,28 +41769,22 @@
                             "/prod/tableau/default/test publish datasource"
                         ]
                     }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.staff,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
                 },
                 {
-                    "id": "test publish datasource"
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "test publish datasource"
+                            }
+                        ]
+                    }
                 }
             ]
         }

--- a/metadata-ingestion/tests/integration/tableau/tableau_extract_all_project_mces_golden.json
+++ b/metadata-ingestion/tests/integration/tableau/tableau_extract_all_project_mces_golden.json
@@ -10936,6 +10936,18 @@
                     }
                 },
                 {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            }
+                        ]
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.common.Ownership": {
                         "owners": [
                             {
@@ -12742,30 +12754,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,801c95e3-b07e-7bfe-3789-a561c7beccd3,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:008e111aa1d250dd52e0fd5d4b307b1a",
-                    "urn": "urn:li:container:008e111aa1d250dd52e0fd5d4b307b1a"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,4644ccb1-2adc-cf26-c654-04ed1dcc7090,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -12777,7 +12765,7 @@
                         "time": 0,
                         "actor": "urn:li:corpuser:unknown"
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,10c6297d-0dbd-44f1-b1ba-458bea446513,PROD)",
                     "type": "TRANSFORMED"
                 },
                 {
@@ -12785,7 +12773,7 @@
                         "time": 0,
                         "actor": "urn:li:corpuser:unknown"
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,10c6297d-0dbd-44f1-b1ba-458bea446513,PROD)",
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
                     "type": "TRANSFORMED"
                 }
             ],
@@ -12878,6 +12866,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
                         ]
                     }
                 },
@@ -13140,30 +13140,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,4644ccb1-2adc-cf26-c654-04ed1dcc7090,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1",
-                    "urn": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,618c87db-5959-338b-bcc7-6f5f4cc0b6c6,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -13208,6 +13184,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
                         ]
                     }
                 },
@@ -13633,30 +13621,6 @@
     "aspect": {
         "json": {
             "container": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,618c87db-5959-338b-bcc7-6f5f4cc0b6c6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1",
-                    "urn": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-                }
-            ]
         }
     },
     "systemMetadata": {
@@ -14112,6 +14076,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
                         ]
                     }
                 },
@@ -14881,30 +14857,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,d00f4ba6-707e-4684-20af-69eb47587cc2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1",
-                    "urn": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,06c3e060-8133-4b58-9b53-a0fced25e056,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -15062,6 +15014,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            }
                         ]
                     }
                 },
@@ -21699,30 +21663,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,06c3e060-8133-4b58-9b53-a0fced25e056,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d",
-                    "urn": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,3ade7817-ae27-259e-8e48-1570e7f932f6,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -21923,6 +21863,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            }
                         ]
                     }
                 },
@@ -25846,30 +25798,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,3ade7817-ae27-259e-8e48-1570e7f932f6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d",
-                    "urn": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,dfe2c02a-54b7-f7a2-39fc-c651da2f6ad8,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -26032,6 +25960,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            }
                         ]
                     }
                 },
@@ -31217,30 +31157,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,dfe2c02a-54b7-f7a2-39fc-c651da2f6ad8,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d",
-                    "urn": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,d8d4c0ea-3162-fa11-31e6-26675da44a38,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -31375,6 +31291,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Workbook published ds"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Workbook published ds"
+                            }
                         ]
                     }
                 },
@@ -31624,30 +31552,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,d8d4c0ea-3162-fa11-31e6-26675da44a38,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:94e6e84b66f9ee8c70c22f06cfbad6a9",
-                    "urn": "urn:li:container:94e6e84b66f9ee8c70c22f06cfbad6a9"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,00cce29f-b561-bb41-3557-8e19660bb5dd,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -31763,6 +31667,15 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            }
                         ]
                     }
                 },
@@ -32058,26 +31971,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,00cce29f-b561-bb41-3557-8e19660bb5dd,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,6cbbeeb2-9f3a-00f6-2342-17139d6e97ae,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -32223,6 +32116,15 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/Samples"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "Samples"
+                            }
                         ]
                     }
                 },
@@ -33122,26 +33024,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,6cbbeeb2-9f3a-00f6-2342-17139d6e97ae,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:d2dcd6bd1bb954d62f1cfc68332ee873",
-                    "urn": "urn:li:container:d2dcd6bd1bb954d62f1cfc68332ee873"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
@@ -33300,6 +33182,18 @@
                     }
                 },
                 {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
+                        ]
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {},
                         "name": "Custom SQL Query",
@@ -33331,30 +33225,6 @@
             "typeNames": [
                 "View",
                 "Custom SQL"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1",
-                    "urn": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-                }
             ]
         }
     },
@@ -33528,6 +33398,15 @@
                     }
                 },
                 {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            }
+                        ]
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {},
                         "name": "Custom SQL Query",
@@ -33559,28 +33438,6 @@
             "typeNames": [
                 "View",
                 "Custom SQL"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,4fb670d5-3e19-9656-e684-74aa9729cf18,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "test publish datasource"
-                }
             ]
         }
     },
@@ -33654,6 +33511,15 @@
                     }
                 },
                 {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "SubProject1"
+                            }
+                        ]
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {},
                         "name": "Custom SQL Query",
@@ -33694,28 +33560,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,10c6297d-0dbd-44f1-b1ba-458bea446513,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "SubProject1"
-                },
-                {
-                    "id": "AbcJoinWorkbook"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity6,PROD)",
@@ -33724,6 +33568,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -33879,31 +33738,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity11,PROD)",
@@ -33912,6 +33746,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -34139,31 +33988,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity11,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity10,PROD)",
@@ -34172,6 +33996,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -34375,31 +34214,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity10,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity7,PROD)",
@@ -34408,6 +34222,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -34563,31 +34392,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity7,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.campaignstable,PROD)",
@@ -34596,6 +34400,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -34739,31 +34558,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.campaignstable,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.address,PROD)",
@@ -34772,6 +34566,25 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook/actor+ (dvdrental)"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            },
+                            {
+                                "id": "actor+ (dvdrental)"
+                            }
                         ]
                     }
                 },
@@ -34903,31 +34716,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Dvdrental Workbook"
-                },
-                {
-                    "id": "actor+ (dvdrental)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.actor,PROD)",
@@ -34936,6 +34724,25 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook/actor+ (dvdrental)"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            },
+                            {
+                                "id": "actor+ (dvdrental)"
+                            }
                         ]
                     }
                 },
@@ -35019,31 +34826,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Dvdrental Workbook"
-                },
-                {
-                    "id": "actor+ (dvdrental)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.people,PROD)",
@@ -35052,6 +34834,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/Samples/Superstore Datasource"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "Samples"
+                            },
+                            {
+                                "id": "Superstore Datasource"
+                            }
                         ]
                     }
                 },
@@ -35111,28 +34905,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.people,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "Samples"
-                },
-                {
-                    "id": "Superstore Datasource"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.returns,PROD)",
@@ -35141,6 +34913,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/Samples/Superstore Datasource"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "Samples"
+                            },
+                            {
+                                "id": "Superstore Datasource"
+                            }
                         ]
                     }
                 },
@@ -35200,28 +34984,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.returns,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "Samples"
-                },
-                {
-                    "id": "Superstore Datasource"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.orders,PROD)",
@@ -35230,6 +34992,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/Samples/Superstore Datasource"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "Samples"
+                            },
+                            {
+                                "id": "Superstore Datasource"
+                            }
                         ]
                     }
                 },
@@ -35517,28 +35291,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.orders,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "Samples"
-                },
-                {
-                    "id": "Superstore Datasource"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.task,PROD)",
@@ -35549,6 +35301,21 @@
                             "/prod/tableau/default/Executive Dashboard/Problems",
                             "/prod/tableau/default/Executive Dashboard/Requests",
                             "/prod/tableau/default/Executive Dashboard/Incidents"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Incidents"
+                            }
                         ]
                     }
                 },
@@ -36328,31 +36095,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.task,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Problems"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_request,PROD)",
@@ -36361,6 +36103,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Requests"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Requests"
+                            }
                         ]
                     }
                 },
@@ -37236,31 +36993,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_request,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Requests"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_req_item,PROD)",
@@ -37269,6 +37001,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Requests"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Requests"
+                            }
                         ]
                     }
                 },
@@ -38216,31 +37963,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_req_item,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Requests"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_cat_item,PROD)",
@@ -38249,6 +37971,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Requests"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Requests"
+                            }
                         ]
                     }
                 },
@@ -39064,31 +38801,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_cat_item,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Requests"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sys_user_group,PROD)",
@@ -39097,6 +38809,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Problems"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Problems"
+                            }
                         ]
                     }
                 },
@@ -39396,31 +39123,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sys_user_group,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Problems"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.problem,PROD)",
@@ -39429,6 +39131,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Problems"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Problems"
+                            }
                         ]
                     }
                 },
@@ -40268,31 +39985,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.problem,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Problems"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.incident,PROD)",
@@ -40301,6 +39993,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Incidents"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Incidents"
+                            }
                         ]
                     }
                 },
@@ -41284,31 +40991,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.incident,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Incidents"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.cmdb_ci,PROD)",
@@ -41317,6 +40999,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Incidents"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Incidents"
+                            }
                         ]
                     }
                 },
@@ -42168,31 +41865,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.cmdb_ci,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Incidents"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.customer,PROD)",
@@ -42204,28 +41876,22 @@
                             "/prod/tableau/default/test publish datasource"
                         ]
                     }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
                 },
                 {
-                    "id": "Customer Payment Query"
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "test publish datasource"
+                            }
+                        ]
+                    }
                 }
             ]
         }
@@ -42247,28 +41913,22 @@
                             "/prod/tableau/default/test publish datasource"
                         ]
                     }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.payment,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
                 },
                 {
-                    "id": "Customer Payment Query"
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "test publish datasource"
+                            }
+                        ]
+                    }
                 }
             ]
         }
@@ -42289,28 +41949,22 @@
                             "/prod/tableau/default/test publish datasource"
                         ]
                     }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.staff,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
                 },
                 {
-                    "id": "test publish datasource"
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "test publish datasource"
+                            }
+                        ]
+                    }
                 }
             ]
         }

--- a/metadata-ingestion/tests/integration/tableau/tableau_mces_golden.json
+++ b/metadata-ingestion/tests/integration/tableau/tableau_mces_golden.json
@@ -10704,6 +10704,18 @@
                     }
                 },
                 {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            }
+                        ]
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.common.Ownership": {
                         "owners": [
                             {
@@ -12510,30 +12522,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,801c95e3-b07e-7bfe-3789-a561c7beccd3,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:008e111aa1d250dd52e0fd5d4b307b1a",
-                    "urn": "urn:li:container:008e111aa1d250dd52e0fd5d4b307b1a"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,4644ccb1-2adc-cf26-c654-04ed1dcc7090,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -12545,7 +12533,7 @@
                         "time": 0,
                         "actor": "urn:li:corpuser:unknown"
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,10c6297d-0dbd-44f1-b1ba-458bea446513,PROD)",
                     "type": "TRANSFORMED"
                 },
                 {
@@ -12553,7 +12541,7 @@
                         "time": 0,
                         "actor": "urn:li:corpuser:unknown"
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,10c6297d-0dbd-44f1-b1ba-458bea446513,PROD)",
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
                     "type": "TRANSFORMED"
                 }
             ],
@@ -12646,6 +12634,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
                         ]
                     }
                 },
@@ -12908,30 +12908,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,4644ccb1-2adc-cf26-c654-04ed1dcc7090,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1",
-                    "urn": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,618c87db-5959-338b-bcc7-6f5f4cc0b6c6,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -12976,6 +12952,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
                         ]
                     }
                 },
@@ -13401,30 +13389,6 @@
     "aspect": {
         "json": {
             "container": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,618c87db-5959-338b-bcc7-6f5f4cc0b6c6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1",
-                    "urn": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-                }
-            ]
         }
     },
     "systemMetadata": {
@@ -13880,6 +13844,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
                         ]
                     }
                 },
@@ -14649,30 +14625,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,d00f4ba6-707e-4684-20af-69eb47587cc2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1",
-                    "urn": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,06c3e060-8133-4b58-9b53-a0fced25e056,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -14830,6 +14782,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            }
                         ]
                     }
                 },
@@ -21467,30 +21431,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,06c3e060-8133-4b58-9b53-a0fced25e056,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d",
-                    "urn": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,3ade7817-ae27-259e-8e48-1570e7f932f6,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -21691,6 +21631,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            }
                         ]
                     }
                 },
@@ -25614,30 +25566,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,3ade7817-ae27-259e-8e48-1570e7f932f6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d",
-                    "urn": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,dfe2c02a-54b7-f7a2-39fc-c651da2f6ad8,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -25800,6 +25728,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            }
                         ]
                     }
                 },
@@ -30985,30 +30925,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,dfe2c02a-54b7-f7a2-39fc-c651da2f6ad8,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d",
-                    "urn": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,d8d4c0ea-3162-fa11-31e6-26675da44a38,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -31143,6 +31059,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Workbook published ds"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Workbook published ds"
+                            }
                         ]
                     }
                 },
@@ -31392,30 +31320,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,d8d4c0ea-3162-fa11-31e6-26675da44a38,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:94e6e84b66f9ee8c70c22f06cfbad6a9",
-                    "urn": "urn:li:container:94e6e84b66f9ee8c70c22f06cfbad6a9"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,00cce29f-b561-bb41-3557-8e19660bb5dd,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -31531,6 +31435,15 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            }
                         ]
                     }
                 },
@@ -31826,26 +31739,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,00cce29f-b561-bb41-3557-8e19660bb5dd,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,6cbbeeb2-9f3a-00f6-2342-17139d6e97ae,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -31991,6 +31884,15 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/Samples"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "Samples"
+                            }
                         ]
                     }
                 },
@@ -32890,26 +32792,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,6cbbeeb2-9f3a-00f6-2342-17139d6e97ae,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:d2dcd6bd1bb954d62f1cfc68332ee873",
-                    "urn": "urn:li:container:d2dcd6bd1bb954d62f1cfc68332ee873"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
@@ -33068,6 +32950,18 @@
                     }
                 },
                 {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
+                        ]
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {},
                         "name": "Custom SQL Query",
@@ -33099,30 +32993,6 @@
             "typeNames": [
                 "View",
                 "Custom SQL"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1",
-                    "urn": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-                }
             ]
         }
     },
@@ -33296,6 +33166,15 @@
                     }
                 },
                 {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            }
+                        ]
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {},
                         "name": "Custom SQL Query",
@@ -33327,28 +33206,6 @@
             "typeNames": [
                 "View",
                 "Custom SQL"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,4fb670d5-3e19-9656-e684-74aa9729cf18,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "test publish datasource"
-                }
             ]
         }
     },
@@ -33422,6 +33279,15 @@
                     }
                 },
                 {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "SubProject1"
+                            }
+                        ]
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {},
                         "name": "Custom SQL Query",
@@ -33462,28 +33328,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,10c6297d-0dbd-44f1-b1ba-458bea446513,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "SubProject1"
-                },
-                {
-                    "id": "AbcJoinWorkbook"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity6,PROD)",
@@ -33492,6 +33336,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -33647,31 +33506,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity11,PROD)",
@@ -33680,6 +33514,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -33907,31 +33756,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity11,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity10,PROD)",
@@ -33940,6 +33764,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -34143,31 +33982,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity10,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity7,PROD)",
@@ -34176,6 +33990,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -34331,31 +34160,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity7,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.campaignstable,PROD)",
@@ -34364,6 +34168,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -34507,31 +34326,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.campaignstable,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.address,PROD)",
@@ -34540,6 +34334,25 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook/actor+ (dvdrental)"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            },
+                            {
+                                "id": "actor+ (dvdrental)"
+                            }
                         ]
                     }
                 },
@@ -34671,31 +34484,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Dvdrental Workbook"
-                },
-                {
-                    "id": "actor+ (dvdrental)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.actor,PROD)",
@@ -34704,6 +34492,25 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook/actor+ (dvdrental)"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            },
+                            {
+                                "id": "actor+ (dvdrental)"
+                            }
                         ]
                     }
                 },
@@ -34787,31 +34594,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Dvdrental Workbook"
-                },
-                {
-                    "id": "actor+ (dvdrental)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.people,PROD)",
@@ -34820,6 +34602,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/Samples/Superstore Datasource"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "Samples"
+                            },
+                            {
+                                "id": "Superstore Datasource"
+                            }
                         ]
                     }
                 },
@@ -34879,28 +34673,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.people,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "Samples"
-                },
-                {
-                    "id": "Superstore Datasource"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.returns,PROD)",
@@ -34909,6 +34681,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/Samples/Superstore Datasource"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "Samples"
+                            },
+                            {
+                                "id": "Superstore Datasource"
+                            }
                         ]
                     }
                 },
@@ -34968,28 +34752,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.returns,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "Samples"
-                },
-                {
-                    "id": "Superstore Datasource"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.orders,PROD)",
@@ -34998,6 +34760,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/Samples/Superstore Datasource"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "Samples"
+                            },
+                            {
+                                "id": "Superstore Datasource"
+                            }
                         ]
                     }
                 },
@@ -35285,28 +35059,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.orders,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "Samples"
-                },
-                {
-                    "id": "Superstore Datasource"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.task,PROD)",
@@ -35317,6 +35069,21 @@
                             "/prod/tableau/default/Executive Dashboard/Problems",
                             "/prod/tableau/default/Executive Dashboard/Requests",
                             "/prod/tableau/default/Executive Dashboard/Incidents"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Incidents"
+                            }
                         ]
                     }
                 },
@@ -36096,31 +35863,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.task,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Problems"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_request,PROD)",
@@ -36129,6 +35871,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Requests"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Requests"
+                            }
                         ]
                     }
                 },
@@ -37004,31 +36761,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_request,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Requests"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_req_item,PROD)",
@@ -37037,6 +36769,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Requests"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Requests"
+                            }
                         ]
                     }
                 },
@@ -37984,31 +37731,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_req_item,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Requests"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_cat_item,PROD)",
@@ -38017,6 +37739,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Requests"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Requests"
+                            }
                         ]
                     }
                 },
@@ -38832,31 +38569,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_cat_item,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Requests"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sys_user_group,PROD)",
@@ -38865,6 +38577,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Problems"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Problems"
+                            }
                         ]
                     }
                 },
@@ -39164,31 +38891,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sys_user_group,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Problems"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.problem,PROD)",
@@ -39197,6 +38899,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Problems"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Problems"
+                            }
                         ]
                     }
                 },
@@ -40036,31 +39753,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.problem,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Problems"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.incident,PROD)",
@@ -40069,6 +39761,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Incidents"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Incidents"
+                            }
                         ]
                     }
                 },
@@ -41052,31 +40759,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.incident,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Incidents"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.cmdb_ci,PROD)",
@@ -41085,6 +40767,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Incidents"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Incidents"
+                            }
                         ]
                     }
                 },
@@ -41936,31 +41633,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.cmdb_ci,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Incidents"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.customer,PROD)",
@@ -41972,28 +41644,22 @@
                             "/prod/tableau/default/test publish datasource"
                         ]
                     }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
                 },
                 {
-                    "id": "Customer Payment Query"
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "test publish datasource"
+                            }
+                        ]
+                    }
                 }
             ]
         }
@@ -42015,28 +41681,22 @@
                             "/prod/tableau/default/test publish datasource"
                         ]
                     }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.payment,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
                 },
                 {
-                    "id": "Customer Payment Query"
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "test publish datasource"
+                            }
+                        ]
+                    }
                 }
             ]
         }
@@ -42057,28 +41717,22 @@
                             "/prod/tableau/default/test publish datasource"
                         ]
                     }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.staff,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
                 },
                 {
-                    "id": "test publish datasource"
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "test publish datasource"
+                            }
+                        ]
+                    }
                 }
             ]
         }

--- a/metadata-ingestion/tests/integration/tableau/tableau_nested_project_mces_golden.json
+++ b/metadata-ingestion/tests/integration/tableau/tableau_nested_project_mces_golden.json
@@ -10936,6 +10936,18 @@
                     }
                 },
                 {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            }
+                        ]
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.common.Ownership": {
                         "owners": [
                             {
@@ -12742,30 +12754,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,801c95e3-b07e-7bfe-3789-a561c7beccd3,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:008e111aa1d250dd52e0fd5d4b307b1a",
-                    "urn": "urn:li:container:008e111aa1d250dd52e0fd5d4b307b1a"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,4644ccb1-2adc-cf26-c654-04ed1dcc7090,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -12777,7 +12765,7 @@
                         "time": 0,
                         "actor": "urn:li:corpuser:unknown"
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,10c6297d-0dbd-44f1-b1ba-458bea446513,PROD)",
                     "type": "TRANSFORMED"
                 },
                 {
@@ -12785,7 +12773,7 @@
                         "time": 0,
                         "actor": "urn:li:corpuser:unknown"
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,10c6297d-0dbd-44f1-b1ba-458bea446513,PROD)",
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
                     "type": "TRANSFORMED"
                 }
             ],
@@ -12878,6 +12866,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
                         ]
                     }
                 },
@@ -13140,30 +13140,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,4644ccb1-2adc-cf26-c654-04ed1dcc7090,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1",
-                    "urn": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,618c87db-5959-338b-bcc7-6f5f4cc0b6c6,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -13208,6 +13184,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
                         ]
                     }
                 },
@@ -13633,30 +13621,6 @@
     "aspect": {
         "json": {
             "container": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,618c87db-5959-338b-bcc7-6f5f4cc0b6c6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1",
-                    "urn": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-                }
-            ]
         }
     },
     "systemMetadata": {
@@ -14112,6 +14076,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
                         ]
                     }
                 },
@@ -14881,30 +14857,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,d00f4ba6-707e-4684-20af-69eb47587cc2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1",
-                    "urn": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,06c3e060-8133-4b58-9b53-a0fced25e056,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -15062,6 +15014,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            }
                         ]
                     }
                 },
@@ -21699,30 +21663,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,06c3e060-8133-4b58-9b53-a0fced25e056,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d",
-                    "urn": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,3ade7817-ae27-259e-8e48-1570e7f932f6,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -21923,6 +21863,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            }
                         ]
                     }
                 },
@@ -25846,30 +25798,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,3ade7817-ae27-259e-8e48-1570e7f932f6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d",
-                    "urn": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,dfe2c02a-54b7-f7a2-39fc-c651da2f6ad8,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -26032,6 +25960,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            }
                         ]
                     }
                 },
@@ -31217,30 +31157,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,dfe2c02a-54b7-f7a2-39fc-c651da2f6ad8,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d",
-                    "urn": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,d8d4c0ea-3162-fa11-31e6-26675da44a38,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -31375,6 +31291,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Workbook published ds"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Workbook published ds"
+                            }
                         ]
                     }
                 },
@@ -31624,30 +31552,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,d8d4c0ea-3162-fa11-31e6-26675da44a38,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:94e6e84b66f9ee8c70c22f06cfbad6a9",
-                    "urn": "urn:li:container:94e6e84b66f9ee8c70c22f06cfbad6a9"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,00cce29f-b561-bb41-3557-8e19660bb5dd,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -31763,6 +31667,15 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            }
                         ]
                     }
                 },
@@ -32058,26 +31971,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,00cce29f-b561-bb41-3557-8e19660bb5dd,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,6cbbeeb2-9f3a-00f6-2342-17139d6e97ae,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -32223,6 +32116,15 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/Samples"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "Samples"
+                            }
                         ]
                     }
                 },
@@ -33122,26 +33024,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,6cbbeeb2-9f3a-00f6-2342-17139d6e97ae,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:d2dcd6bd1bb954d62f1cfc68332ee873",
-                    "urn": "urn:li:container:d2dcd6bd1bb954d62f1cfc68332ee873"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
@@ -33300,6 +33182,18 @@
                     }
                 },
                 {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
+                        ]
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {},
                         "name": "Custom SQL Query",
@@ -33331,30 +33225,6 @@
             "typeNames": [
                 "View",
                 "Custom SQL"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1",
-                    "urn": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-                }
             ]
         }
     },
@@ -33528,6 +33398,15 @@
                     }
                 },
                 {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            }
+                        ]
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {},
                         "name": "Custom SQL Query",
@@ -33559,28 +33438,6 @@
             "typeNames": [
                 "View",
                 "Custom SQL"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,4fb670d5-3e19-9656-e684-74aa9729cf18,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "test publish datasource"
-                }
             ]
         }
     },
@@ -33647,6 +33504,11 @@
                     }
                 },
                 {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": []
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {},
                         "name": "Custom SQL Query",
@@ -33695,6 +33557,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -33850,31 +33727,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity11,PROD)",
@@ -33883,6 +33735,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -34110,31 +33977,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity11,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity10,PROD)",
@@ -34143,6 +33985,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -34346,31 +34203,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity10,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity7,PROD)",
@@ -34379,6 +34211,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -34534,31 +34381,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity7,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.campaignstable,PROD)",
@@ -34567,6 +34389,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -34710,31 +34547,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.campaignstable,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.address,PROD)",
@@ -34743,6 +34555,25 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook/actor+ (dvdrental)"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            },
+                            {
+                                "id": "actor+ (dvdrental)"
+                            }
                         ]
                     }
                 },
@@ -34874,31 +34705,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Dvdrental Workbook"
-                },
-                {
-                    "id": "actor+ (dvdrental)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.actor,PROD)",
@@ -34907,6 +34713,25 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook/actor+ (dvdrental)"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            },
+                            {
+                                "id": "actor+ (dvdrental)"
+                            }
                         ]
                     }
                 },
@@ -34990,31 +34815,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Dvdrental Workbook"
-                },
-                {
-                    "id": "actor+ (dvdrental)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.people,PROD)",
@@ -35023,6 +34823,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/Samples/Superstore Datasource"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "Samples"
+                            },
+                            {
+                                "id": "Superstore Datasource"
+                            }
                         ]
                     }
                 },
@@ -35082,28 +34894,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.people,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "Samples"
-                },
-                {
-                    "id": "Superstore Datasource"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.returns,PROD)",
@@ -35112,6 +34902,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/Samples/Superstore Datasource"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "Samples"
+                            },
+                            {
+                                "id": "Superstore Datasource"
+                            }
                         ]
                     }
                 },
@@ -35171,28 +34973,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.returns,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "Samples"
-                },
-                {
-                    "id": "Superstore Datasource"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.orders,PROD)",
@@ -35201,6 +34981,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/Samples/Superstore Datasource"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "Samples"
+                            },
+                            {
+                                "id": "Superstore Datasource"
+                            }
                         ]
                     }
                 },
@@ -35488,28 +35280,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.orders,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "Samples"
-                },
-                {
-                    "id": "Superstore Datasource"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.task,PROD)",
@@ -35520,6 +35290,21 @@
                             "/prod/tableau/default/Executive Dashboard/Problems",
                             "/prod/tableau/default/Executive Dashboard/Requests",
                             "/prod/tableau/default/Executive Dashboard/Incidents"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Incidents"
+                            }
                         ]
                     }
                 },
@@ -36299,31 +36084,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.task,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Problems"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_request,PROD)",
@@ -36332,6 +36092,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Requests"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Requests"
+                            }
                         ]
                     }
                 },
@@ -37207,31 +36982,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_request,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Requests"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_req_item,PROD)",
@@ -37240,6 +36990,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Requests"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Requests"
+                            }
                         ]
                     }
                 },
@@ -38187,31 +37952,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_req_item,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Requests"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_cat_item,PROD)",
@@ -38220,6 +37960,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Requests"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Requests"
+                            }
                         ]
                     }
                 },
@@ -39035,31 +38790,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_cat_item,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Requests"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sys_user_group,PROD)",
@@ -39068,6 +38798,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Problems"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Problems"
+                            }
                         ]
                     }
                 },
@@ -39367,31 +39112,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sys_user_group,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Problems"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.problem,PROD)",
@@ -39400,6 +39120,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Problems"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Problems"
+                            }
                         ]
                     }
                 },
@@ -40239,31 +39974,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.problem,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Problems"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.incident,PROD)",
@@ -40272,6 +39982,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Incidents"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Incidents"
+                            }
                         ]
                     }
                 },
@@ -41255,31 +40980,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.incident,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Incidents"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.cmdb_ci,PROD)",
@@ -41288,6 +40988,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Incidents"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Incidents"
+                            }
                         ]
                     }
                 },
@@ -42139,31 +41854,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.cmdb_ci,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Incidents"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.customer,PROD)",
@@ -42175,28 +41865,22 @@
                             "/prod/tableau/default/test publish datasource"
                         ]
                     }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
                 },
                 {
-                    "id": "Customer Payment Query"
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "test publish datasource"
+                            }
+                        ]
+                    }
                 }
             ]
         }
@@ -42218,28 +41902,22 @@
                             "/prod/tableau/default/test publish datasource"
                         ]
                     }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.payment,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
                 },
                 {
-                    "id": "Customer Payment Query"
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "test publish datasource"
+                            }
+                        ]
+                    }
                 }
             ]
         }
@@ -42260,28 +41938,22 @@
                             "/prod/tableau/default/test publish datasource"
                         ]
                     }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.staff,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
                 },
                 {
-                    "id": "test publish datasource"
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "test publish datasource"
+                            }
+                        ]
+                    }
                 }
             ]
         }

--- a/metadata-ingestion/tests/integration/tableau/tableau_signout_timeout_mces_golden.json
+++ b/metadata-ingestion/tests/integration/tableau/tableau_signout_timeout_mces_golden.json
@@ -10704,6 +10704,18 @@
                     }
                 },
                 {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            }
+                        ]
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.common.Ownership": {
                         "owners": [
                             {
@@ -12510,30 +12522,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,801c95e3-b07e-7bfe-3789-a561c7beccd3,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:008e111aa1d250dd52e0fd5d4b307b1a",
-                    "urn": "urn:li:container:008e111aa1d250dd52e0fd5d4b307b1a"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,4644ccb1-2adc-cf26-c654-04ed1dcc7090,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -12545,7 +12533,7 @@
                         "time": 0,
                         "actor": "urn:li:corpuser:unknown"
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,10c6297d-0dbd-44f1-b1ba-458bea446513,PROD)",
                     "type": "TRANSFORMED"
                 },
                 {
@@ -12553,7 +12541,7 @@
                         "time": 0,
                         "actor": "urn:li:corpuser:unknown"
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,10c6297d-0dbd-44f1-b1ba-458bea446513,PROD)",
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
                     "type": "TRANSFORMED"
                 }
             ],
@@ -12646,6 +12634,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
                         ]
                     }
                 },
@@ -12908,30 +12908,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,4644ccb1-2adc-cf26-c654-04ed1dcc7090,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1",
-                    "urn": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,618c87db-5959-338b-bcc7-6f5f4cc0b6c6,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -12976,6 +12952,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
                         ]
                     }
                 },
@@ -13401,30 +13389,6 @@
     "aspect": {
         "json": {
             "container": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,618c87db-5959-338b-bcc7-6f5f4cc0b6c6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1",
-                    "urn": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-                }
-            ]
         }
     },
     "systemMetadata": {
@@ -13880,6 +13844,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
                         ]
                     }
                 },
@@ -14649,30 +14625,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,d00f4ba6-707e-4684-20af-69eb47587cc2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1",
-                    "urn": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,06c3e060-8133-4b58-9b53-a0fced25e056,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -14830,6 +14782,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            }
                         ]
                     }
                 },
@@ -21467,30 +21431,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,06c3e060-8133-4b58-9b53-a0fced25e056,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d",
-                    "urn": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,3ade7817-ae27-259e-8e48-1570e7f932f6,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -21691,6 +21631,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            }
                         ]
                     }
                 },
@@ -25614,30 +25566,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,3ade7817-ae27-259e-8e48-1570e7f932f6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d",
-                    "urn": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,dfe2c02a-54b7-f7a2-39fc-c651da2f6ad8,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -25800,6 +25728,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            }
                         ]
                     }
                 },
@@ -30985,30 +30925,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,dfe2c02a-54b7-f7a2-39fc-c651da2f6ad8,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d",
-                    "urn": "urn:li:container:047691e9c16bec8fb08e1df0f5d71c4d"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,d8d4c0ea-3162-fa11-31e6-26675da44a38,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -31143,6 +31059,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Workbook published ds"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Workbook published ds"
+                            }
                         ]
                     }
                 },
@@ -31392,30 +31320,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,d8d4c0ea-3162-fa11-31e6-26675da44a38,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:94e6e84b66f9ee8c70c22f06cfbad6a9",
-                    "urn": "urn:li:container:94e6e84b66f9ee8c70c22f06cfbad6a9"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,00cce29f-b561-bb41-3557-8e19660bb5dd,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -31531,6 +31435,15 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            }
                         ]
                     }
                 },
@@ -31826,26 +31739,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,00cce29f-b561-bb41-3557-8e19660bb5dd,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,6cbbeeb2-9f3a-00f6-2342-17139d6e97ae,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -31991,6 +31884,15 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/Samples"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "Samples"
+                            }
                         ]
                     }
                 },
@@ -32890,26 +32792,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,6cbbeeb2-9f3a-00f6-2342-17139d6e97ae,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:d2dcd6bd1bb954d62f1cfc68332ee873",
-                    "urn": "urn:li:container:d2dcd6bd1bb954d62f1cfc68332ee873"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
@@ -33068,6 +32950,18 @@
                     }
                 },
                 {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
+                        ]
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {},
                         "name": "Custom SQL Query",
@@ -33099,30 +32993,6 @@
             "typeNames": [
                 "View",
                 "Custom SQL"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b",
-                    "urn": "urn:li:container:5ec314b9630974ec084f5dfd3849f87b"
-                },
-                {
-                    "id": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1",
-                    "urn": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1"
-                }
             ]
         }
     },
@@ -33296,6 +33166,15 @@
                     }
                 },
                 {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            }
+                        ]
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {},
                         "name": "Custom SQL Query",
@@ -33327,28 +33206,6 @@
             "typeNames": [
                 "View",
                 "Custom SQL"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,4fb670d5-3e19-9656-e684-74aa9729cf18,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "test publish datasource"
-                }
             ]
         }
     },
@@ -33422,6 +33279,15 @@
                     }
                 },
                 {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "SubProject1"
+                            }
+                        ]
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {},
                         "name": "Custom SQL Query",
@@ -33462,28 +33328,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,10c6297d-0dbd-44f1-b1ba-458bea446513,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "SubProject1"
-                },
-                {
-                    "id": "AbcJoinWorkbook"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity6,PROD)",
@@ -33492,6 +33336,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -33647,31 +33506,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity11,PROD)",
@@ -33680,6 +33514,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -33907,31 +33756,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity11,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity10,PROD)",
@@ -33940,6 +33764,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -34143,31 +33982,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity10,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity7,PROD)",
@@ -34176,6 +33990,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -34331,31 +34160,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity7,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.campaignstable,PROD)",
@@ -34364,6 +34168,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -34507,31 +34326,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.campaignstable,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.address,PROD)",
@@ -34540,6 +34334,25 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook/actor+ (dvdrental)"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            },
+                            {
+                                "id": "actor+ (dvdrental)"
+                            }
                         ]
                     }
                 },
@@ -34671,31 +34484,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Dvdrental Workbook"
-                },
-                {
-                    "id": "actor+ (dvdrental)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.actor,PROD)",
@@ -34704,6 +34492,25 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Dvdrental Workbook/actor+ (dvdrental)"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            },
+                            {
+                                "id": "actor+ (dvdrental)"
+                            }
                         ]
                     }
                 },
@@ -34787,31 +34594,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Dvdrental Workbook"
-                },
-                {
-                    "id": "actor+ (dvdrental)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.people,PROD)",
@@ -34820,6 +34602,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/Samples/Superstore Datasource"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "Samples"
+                            },
+                            {
+                                "id": "Superstore Datasource"
+                            }
                         ]
                     }
                 },
@@ -34879,28 +34673,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.people,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "Samples"
-                },
-                {
-                    "id": "Superstore Datasource"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.returns,PROD)",
@@ -34909,6 +34681,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/Samples/Superstore Datasource"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "Samples"
+                            },
+                            {
+                                "id": "Superstore Datasource"
+                            }
                         ]
                     }
                 },
@@ -34968,28 +34752,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.returns,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "Samples"
-                },
-                {
-                    "id": "Superstore Datasource"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.orders,PROD)",
@@ -34998,6 +34760,18 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/Samples/Superstore Datasource"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "Samples"
+                            },
+                            {
+                                "id": "Superstore Datasource"
+                            }
                         ]
                     }
                 },
@@ -35285,28 +35059,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.orders,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "Samples"
-                },
-                {
-                    "id": "Superstore Datasource"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.task,PROD)",
@@ -35317,6 +35069,21 @@
                             "/prod/tableau/default/Executive Dashboard/Problems",
                             "/prod/tableau/default/Executive Dashboard/Requests",
                             "/prod/tableau/default/Executive Dashboard/Incidents"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Incidents"
+                            }
                         ]
                     }
                 },
@@ -36096,31 +35863,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.task,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Problems"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_request,PROD)",
@@ -36129,6 +35871,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Requests"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Requests"
+                            }
                         ]
                     }
                 },
@@ -37004,31 +36761,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_request,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Requests"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_req_item,PROD)",
@@ -37037,6 +36769,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Requests"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Requests"
+                            }
                         ]
                     }
                 },
@@ -37984,31 +37731,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_req_item,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Requests"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_cat_item,PROD)",
@@ -38017,6 +37739,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Requests"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Requests"
+                            }
                         ]
                     }
                 },
@@ -38832,31 +38569,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_cat_item,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Requests"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sys_user_group,PROD)",
@@ -38865,6 +38577,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Problems"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Problems"
+                            }
                         ]
                     }
                 },
@@ -39164,31 +38891,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sys_user_group,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Problems"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.problem,PROD)",
@@ -39197,6 +38899,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Problems"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Problems"
+                            }
                         ]
                     }
                 },
@@ -40036,31 +39753,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.problem,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Problems"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.incident,PROD)",
@@ -40069,6 +39761,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Incidents"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Incidents"
+                            }
                         ]
                     }
                 },
@@ -41052,31 +40759,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.incident,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Incidents"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.cmdb_ci,PROD)",
@@ -41085,6 +40767,21 @@
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
                             "/prod/tableau/default/Executive Dashboard/Incidents"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Incidents"
+                            }
                         ]
                     }
                 },
@@ -41936,31 +41633,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.cmdb_ci,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Incidents"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.customer,PROD)",
@@ -41972,28 +41644,22 @@
                             "/prod/tableau/default/test publish datasource"
                         ]
                     }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
                 },
                 {
-                    "id": "Customer Payment Query"
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "test publish datasource"
+                            }
+                        ]
+                    }
                 }
             ]
         }
@@ -42015,28 +41681,22 @@
                             "/prod/tableau/default/test publish datasource"
                         ]
                     }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.payment,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
                 },
                 {
-                    "id": "Customer Payment Query"
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "test publish datasource"
+                            }
+                        ]
+                    }
                 }
             ]
         }
@@ -42057,28 +41717,22 @@
                             "/prod/tableau/default/test publish datasource"
                         ]
                     }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.staff,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "default"
                 },
                 {
-                    "id": "test publish datasource"
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "test publish datasource"
+                            }
+                        ]
+                    }
                 }
             ]
         }

--- a/metadata-ingestion/tests/integration/tableau/tableau_with_platform_instance_mces_golden.json
+++ b/metadata-ingestion/tests/integration/tableau/tableau_with_platform_instance_mces_golden.json
@@ -785,7 +785,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Email Performance by Campaign"
+                            "/tableau/acryl_site1/default/Email Performance by Campaign"
                         ]
                     }
                 },
@@ -1063,7 +1063,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Email Performance by Campaign"
+                            "/tableau/acryl_site1/default/Email Performance by Campaign"
                         ]
                     }
                 },
@@ -1627,7 +1627,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Email Performance by Campaign"
+                            "/tableau/acryl_site1/default/Email Performance by Campaign"
                         ]
                     }
                 },
@@ -2243,7 +2243,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Email Performance by Campaign"
+                            "/tableau/acryl_site1/default/Email Performance by Campaign"
                         ]
                     }
                 },
@@ -2755,7 +2755,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Dvdrental Workbook"
+                            "/tableau/acryl_site1/default/Dvdrental Workbook"
                         ]
                     }
                 },
@@ -2903,7 +2903,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Dvdrental Workbook"
+                            "/tableau/acryl_site1/default/Dvdrental Workbook"
                         ]
                     }
                 },
@@ -3219,7 +3219,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Dvdrental Workbook"
+                            "/tableau/acryl_site1/default/Dvdrental Workbook"
                         ]
                     }
                 },
@@ -3422,7 +3422,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Executive Dashboard"
+                            "/tableau/acryl_site1/default/Executive Dashboard"
                         ]
                     }
                 },
@@ -3926,7 +3926,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Executive Dashboard"
+                            "/tableau/acryl_site1/default/Executive Dashboard"
                         ]
                     }
                 },
@@ -4398,7 +4398,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Executive Dashboard"
+                            "/tableau/acryl_site1/default/Executive Dashboard"
                         ]
                     }
                 },
@@ -4899,7 +4899,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Executive Dashboard"
+                            "/tableau/acryl_site1/default/Executive Dashboard"
                         ]
                     }
                 },
@@ -5287,7 +5287,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Executive Dashboard"
+                            "/tableau/acryl_site1/default/Executive Dashboard"
                         ]
                     }
                 },
@@ -5649,7 +5649,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Executive Dashboard"
+                            "/tableau/acryl_site1/default/Executive Dashboard"
                         ]
                     }
                 },
@@ -6040,7 +6040,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Executive Dashboard"
+                            "/tableau/acryl_site1/default/Executive Dashboard"
                         ]
                     }
                 },
@@ -6483,7 +6483,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Executive Dashboard"
+                            "/tableau/acryl_site1/default/Executive Dashboard"
                         ]
                     }
                 },
@@ -6897,7 +6897,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Executive Dashboard"
+                            "/tableau/acryl_site1/default/Executive Dashboard"
                         ]
                     }
                 },
@@ -7233,7 +7233,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Executive Dashboard"
+                            "/tableau/acryl_site1/default/Executive Dashboard"
                         ]
                     }
                 },
@@ -7595,7 +7595,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Executive Dashboard"
+                            "/tableau/acryl_site1/default/Executive Dashboard"
                         ]
                     }
                 },
@@ -7853,7 +7853,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Executive Dashboard"
+                            "/tableau/acryl_site1/default/Executive Dashboard"
                         ]
                     }
                 },
@@ -8296,7 +8296,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Executive Dashboard"
+                            "/tableau/acryl_site1/default/Executive Dashboard"
                         ]
                     }
                 },
@@ -8635,7 +8635,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Executive Dashboard"
+                            "/tableau/acryl_site1/default/Executive Dashboard"
                         ]
                     }
                 },
@@ -9000,7 +9000,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Executive Dashboard"
+                            "/tableau/acryl_site1/default/Executive Dashboard"
                         ]
                     }
                 },
@@ -9388,7 +9388,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Executive Dashboard"
+                            "/tableau/acryl_site1/default/Executive Dashboard"
                         ]
                     }
                 },
@@ -9831,7 +9831,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Workbook published ds"
+                            "/tableau/acryl_site1/default/Workbook published ds"
                         ]
                     }
                 },
@@ -10046,7 +10046,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Email Performance by Campaign"
+                            "/tableau/acryl_site1/default/Email Performance by Campaign"
                         ]
                     }
                 },
@@ -10151,7 +10151,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Dvdrental Workbook"
+                            "/tableau/acryl_site1/default/Dvdrental Workbook"
                         ]
                     }
                 },
@@ -10254,7 +10254,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Dvdrental Workbook"
+                            "/tableau/acryl_site1/default/Dvdrental Workbook"
                         ]
                     }
                 },
@@ -10371,7 +10371,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/tableau/default/Executive Dashboard"
+                            "/tableau/acryl_site1/default/Executive Dashboard"
                         ]
                     }
                 },
@@ -10797,7 +10797,23 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Email Performance by Campaign"
+                            "/prod/tableau/acryl_site1/default/Email Performance by Campaign"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            }
                         ]
                     }
                 },
@@ -12608,34 +12624,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.801c95e3-b07e-7bfe-3789-a561c7beccd3,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
-                    "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
-                },
-                {
-                    "id": "urn:li:container:8533f62e6c2cd132ff69f1ff5a9ce1f5",
-                    "urn": "urn:li:container:8533f62e6c2cd132ff69f1ff5a9ce1f5"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.4644ccb1-2adc-cf26-c654-04ed1dcc7090,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -12647,7 +12635,7 @@
                         "time": 0,
                         "actor": "urn:li:corpuser:unknown"
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.10c6297d-0dbd-44f1-b1ba-458bea446513,PROD)",
                     "type": "TRANSFORMED"
                 },
                 {
@@ -12655,7 +12643,7 @@
                         "time": 0,
                         "actor": "urn:li:corpuser:unknown"
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.10c6297d-0dbd-44f1-b1ba-458bea446513,PROD)",
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
                     "type": "TRANSFORMED"
                 }
             ],
@@ -12748,7 +12736,23 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Dvdrental Workbook"
+                            "/prod/tableau/acryl_site1/default/Dvdrental Workbook"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
                         ]
                     }
                 },
@@ -13011,34 +13015,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.4644ccb1-2adc-cf26-c654-04ed1dcc7090,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
-                    "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
-                },
-                {
-                    "id": "urn:li:container:fd3437da0a5c1a43130608562ba3f532",
-                    "urn": "urn:li:container:fd3437da0a5c1a43130608562ba3f532"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.618c87db-5959-338b-bcc7-6f5f4cc0b6c6,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -13083,7 +13059,23 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Dvdrental Workbook"
+                            "/prod/tableau/acryl_site1/default/Dvdrental Workbook"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
                         ]
                     }
                 },
@@ -13509,34 +13501,6 @@
     "aspect": {
         "json": {
             "container": "urn:li:container:fd3437da0a5c1a43130608562ba3f532"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.618c87db-5959-338b-bcc7-6f5f4cc0b6c6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
-                    "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
-                },
-                {
-                    "id": "urn:li:container:fd3437da0a5c1a43130608562ba3f532",
-                    "urn": "urn:li:container:fd3437da0a5c1a43130608562ba3f532"
-                }
-            ]
         }
     },
     "systemMetadata": {
@@ -13992,7 +13956,23 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Dvdrental Workbook"
+                            "/prod/tableau/acryl_site1/default/Dvdrental Workbook"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
                         ]
                     }
                 },
@@ -14762,34 +14742,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.d00f4ba6-707e-4684-20af-69eb47587cc2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
-                    "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
-                },
-                {
-                    "id": "urn:li:container:fd3437da0a5c1a43130608562ba3f532",
-                    "urn": "urn:li:container:fd3437da0a5c1a43130608562ba3f532"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.06c3e060-8133-4b58-9b53-a0fced25e056,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -14947,7 +14899,23 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Executive Dashboard"
+                            "/prod/tableau/acryl_site1/default/Executive Dashboard"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            }
                         ]
                     }
                 },
@@ -21585,34 +21553,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.06c3e060-8133-4b58-9b53-a0fced25e056,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
-                    "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
-                },
-                {
-                    "id": "urn:li:container:c209b64f2002cc0839094edcef4b180e",
-                    "urn": "urn:li:container:c209b64f2002cc0839094edcef4b180e"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.3ade7817-ae27-259e-8e48-1570e7f932f6,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -21813,7 +21753,23 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Executive Dashboard"
+                            "/prod/tableau/acryl_site1/default/Executive Dashboard"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            }
                         ]
                     }
                 },
@@ -25737,34 +25693,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.3ade7817-ae27-259e-8e48-1570e7f932f6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
-                    "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
-                },
-                {
-                    "id": "urn:li:container:c209b64f2002cc0839094edcef4b180e",
-                    "urn": "urn:li:container:c209b64f2002cc0839094edcef4b180e"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.dfe2c02a-54b7-f7a2-39fc-c651da2f6ad8,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -25927,7 +25855,23 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Executive Dashboard"
+                            "/prod/tableau/acryl_site1/default/Executive Dashboard"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            }
                         ]
                     }
                 },
@@ -31113,34 +31057,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.dfe2c02a-54b7-f7a2-39fc-c651da2f6ad8,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
-                    "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
-                },
-                {
-                    "id": "urn:li:container:c209b64f2002cc0839094edcef4b180e",
-                    "urn": "urn:li:container:c209b64f2002cc0839094edcef4b180e"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.d8d4c0ea-3162-fa11-31e6-26675da44a38,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -31275,7 +31191,23 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Workbook published ds"
+                            "/prod/tableau/acryl_site1/default/Workbook published ds"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Workbook published ds"
+                            }
                         ]
                     }
                 },
@@ -31525,34 +31457,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.d8d4c0ea-3162-fa11-31e6-26675da44a38,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
-                    "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
-                },
-                {
-                    "id": "urn:li:container:ba8a5ac7eb4c6e5edc9b03bf8891be55",
-                    "urn": "urn:li:container:ba8a5ac7eb4c6e5edc9b03bf8891be55"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.00cce29f-b561-bb41-3557-8e19660bb5dd,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -31668,7 +31572,20 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default"
+                            "/prod/tableau/acryl_site1/default"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            }
                         ]
                     }
                 },
@@ -31964,30 +31881,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.00cce29f-b561-bb41-3557-8e19660bb5dd,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
-                    "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.6cbbeeb2-9f3a-00f6-2342-17139d6e97ae,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
@@ -32133,7 +32026,20 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/Samples"
+                            "/prod/tableau/acryl_site1/Samples"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                            },
+                            {
+                                "id": "Samples"
+                            }
                         ]
                     }
                 },
@@ -33018,29 +32924,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.6cbbeeb2-9f3a-00f6-2342-17139d6e97ae,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "Samples"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
@@ -33195,7 +33078,23 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Customer Payment Query"
+                            "/prod/tableau/acryl_site1/default/Customer Payment Query"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            }
                         ]
                     }
                 },
@@ -33231,34 +33130,6 @@
             "typeNames": [
                 "View",
                 "Custom SQL"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.22b0b4c3-6b85-713d-a161-5a87fdd78f40,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
-                    "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
-                },
-                {
-                    "id": "urn:li:container:fd3437da0a5c1a43130608562ba3f532",
-                    "urn": "urn:li:container:fd3437da0a5c1a43130608562ba3f532"
-                }
             ]
         }
     },
@@ -33428,7 +33299,20 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/test publish datasource"
+                            "/prod/tableau/acryl_site1/default/test publish datasource"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            }
                         ]
                     }
                 },
@@ -33464,32 +33348,6 @@
             "typeNames": [
                 "View",
                 "Custom SQL"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.4fb670d5-3e19-9656-e684-74aa9729cf18,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "test publish datasource"
-                }
             ]
         }
     },
@@ -33559,7 +33417,20 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/SubProject1/AbcJoinWorkbook"
+                            "/prod/tableau/acryl_site1/SubProject1/AbcJoinWorkbook"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                            },
+                            {
+                                "id": "SubProject1"
+                            }
                         ]
                     }
                 },
@@ -33604,32 +33475,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:tableau,acryl_site1.10c6297d-0dbd-44f1-b1ba-458bea446513,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "SubProject1"
-                },
-                {
-                    "id": "AbcJoinWorkbook"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity6,PROD)",
@@ -33637,7 +33482,26 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                            "/prod/tableau/acryl_site1/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:marketo-marketo,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:marketo-marketo,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -33793,35 +33657,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity11,PROD)",
@@ -33829,7 +33664,26 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                            "/prod/tableau/acryl_site1/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:marketo-marketo,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:marketo-marketo,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -34057,35 +33911,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity11,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity10,PROD)",
@@ -34093,7 +33918,26 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                            "/prod/tableau/acryl_site1/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:marketo-marketo,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:marketo-marketo,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -34297,35 +34141,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity10,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity7,PROD)",
@@ -34333,7 +34148,26 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                            "/prod/tableau/acryl_site1/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:marketo-marketo,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:marketo-marketo,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -34489,35 +34323,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.activity7,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.campaignstable,PROD)",
@@ -34525,7 +34330,26 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Email Performance by Campaign/Marketo"
+                            "/prod/tableau/acryl_site1/default/Email Performance by Campaign/Marketo"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:marketo-marketo,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:marketo-marketo,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Email Performance by Campaign"
+                            },
+                            {
+                                "id": "Marketo"
+                            }
                         ]
                     }
                 },
@@ -34669,35 +34493,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:marketo-marketo,marketo.campaignstable,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Email Performance by Campaign"
-                },
-                {
-                    "id": "Marketo"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.address,PROD)",
@@ -34705,7 +34500,26 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Dvdrental Workbook/actor+ (dvdrental)"
+                            "/prod/tableau/acryl_site1/default/Dvdrental Workbook/actor+ (dvdrental)"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            },
+                            {
+                                "id": "actor+ (dvdrental)"
+                            }
                         ]
                     }
                 },
@@ -34837,35 +34651,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.address,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Dvdrental Workbook"
-                },
-                {
-                    "id": "actor+ (dvdrental)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.actor,PROD)",
@@ -34873,7 +34658,26 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Dvdrental Workbook/actor+ (dvdrental)"
+                            "/prod/tableau/acryl_site1/default/Dvdrental Workbook/actor+ (dvdrental)"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Dvdrental Workbook"
+                            },
+                            {
+                                "id": "actor+ (dvdrental)"
+                            }
                         ]
                     }
                 },
@@ -34957,35 +34761,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.actor,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Dvdrental Workbook"
-                },
-                {
-                    "id": "actor+ (dvdrental)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.people,PROD)",
@@ -34993,7 +34768,23 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/Samples/Superstore Datasource"
+                            "/prod/tableau/acryl_site1/Samples/Superstore Datasource"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:external,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:external,acryl_site1)"
+                            },
+                            {
+                                "id": "Samples"
+                            },
+                            {
+                                "id": "Superstore Datasource"
+                            }
                         ]
                     }
                 },
@@ -35053,32 +34844,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.people,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "Samples"
-                },
-                {
-                    "id": "Superstore Datasource"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.returns,PROD)",
@@ -35086,7 +34851,23 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/Samples/Superstore Datasource"
+                            "/prod/tableau/acryl_site1/Samples/Superstore Datasource"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:external,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:external,acryl_site1)"
+                            },
+                            {
+                                "id": "Samples"
+                            },
+                            {
+                                "id": "Superstore Datasource"
+                            }
                         ]
                     }
                 },
@@ -35146,32 +34927,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.returns,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "Samples"
-                },
-                {
-                    "id": "Superstore Datasource"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.orders,PROD)",
@@ -35179,7 +34934,23 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/Samples/Superstore Datasource"
+                            "/prod/tableau/acryl_site1/Samples/Superstore Datasource"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:external,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:external,acryl_site1)"
+                            },
+                            {
+                                "id": "Samples"
+                            },
+                            {
+                                "id": "Superstore Datasource"
+                            }
                         ]
                     }
                 },
@@ -35467,32 +35238,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:external,sample - superstore%2C %28new%29.xls.orders,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "Samples"
-                },
-                {
-                    "id": "Superstore Datasource"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.task,PROD)",
@@ -35500,9 +35245,28 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Executive Dashboard/Problems",
-                            "/prod/tableau/default/Executive Dashboard/Requests",
-                            "/prod/tableau/default/Executive Dashboard/Incidents"
+                            "/prod/tableau/acryl_site1/default/Executive Dashboard/Problems",
+                            "/prod/tableau/acryl_site1/default/Executive Dashboard/Requests",
+                            "/prod/tableau/acryl_site1/default/Executive Dashboard/Incidents"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Incidents"
+                            }
                         ]
                     }
                 },
@@ -36282,35 +36046,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.task,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Problems"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_request,PROD)",
@@ -36318,7 +36053,26 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Executive Dashboard/Requests"
+                            "/prod/tableau/acryl_site1/default/Executive Dashboard/Requests"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Requests"
+                            }
                         ]
                     }
                 },
@@ -37194,35 +36948,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_request,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Requests"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_req_item,PROD)",
@@ -37230,7 +36955,26 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Executive Dashboard/Requests"
+                            "/prod/tableau/acryl_site1/default/Executive Dashboard/Requests"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Requests"
+                            }
                         ]
                     }
                 },
@@ -38178,35 +37922,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_req_item,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Requests"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_cat_item,PROD)",
@@ -38214,7 +37929,26 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Executive Dashboard/Requests"
+                            "/prod/tableau/acryl_site1/default/Executive Dashboard/Requests"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Requests"
+                            }
                         ]
                     }
                 },
@@ -39030,35 +38764,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sc_cat_item,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Requests"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sys_user_group,PROD)",
@@ -39066,7 +38771,26 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Executive Dashboard/Problems"
+                            "/prod/tableau/acryl_site1/default/Executive Dashboard/Problems"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Problems"
+                            }
                         ]
                     }
                 },
@@ -39366,35 +39090,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.sys_user_group,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Problems"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.problem,PROD)",
@@ -39402,7 +39097,26 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Executive Dashboard/Problems"
+                            "/prod/tableau/acryl_site1/default/Executive Dashboard/Problems"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Problems"
+                            }
                         ]
                     }
                 },
@@ -40242,35 +39956,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.problem,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Problems"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.incident,PROD)",
@@ -40278,7 +39963,26 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Executive Dashboard/Incidents"
+                            "/prod/tableau/acryl_site1/default/Executive Dashboard/Incidents"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Incidents"
+                            }
                         ]
                     }
                 },
@@ -41262,35 +40966,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.incident,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Incidents"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.cmdb_ci,PROD)",
@@ -41298,7 +40973,26 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Executive Dashboard/Incidents"
+                            "/prod/tableau/acryl_site1/default/Executive Dashboard/Incidents"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,acryl_site1)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,acryl_site1)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "Executive Dashboard"
+                            },
+                            {
+                                "id": "Incidents"
+                            }
                         ]
                     }
                 },
@@ -42150,35 +41844,6 @@
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:webdata-direct:servicenowitsm-servicenowitsm,ven01911.cmdb_ci,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
-                },
-                {
-                    "id": "default"
-                },
-                {
-                    "id": "Executive Dashboard"
-                },
-                {
-                    "id": "Incidents"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.customer,PROD)",
@@ -42186,36 +41851,26 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Customer Payment Query",
-                            "/prod/tableau/default/test publish datasource"
+                            "/prod/tableau/acryl_site1/default/Customer Payment Query",
+                            "/prod/tableau/acryl_site1/default/test publish datasource"
                         ]
                     }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.customer,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
                 },
                 {
-                    "id": "default"
-                },
-                {
-                    "id": "Customer Payment Query"
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "test publish datasource"
+                            }
+                        ]
+                    }
                 }
             ]
         }
@@ -42233,36 +41888,26 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/Customer Payment Query",
-                            "/prod/tableau/default/test publish datasource"
+                            "/prod/tableau/acryl_site1/default/Customer Payment Query",
+                            "/prod/tableau/acryl_site1/default/test publish datasource"
                         ]
                     }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.payment,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
                 },
                 {
-                    "id": "default"
-                },
-                {
-                    "id": "Customer Payment Query"
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "test publish datasource"
+                            }
+                        ]
+                    }
                 }
             ]
         }
@@ -42280,35 +41925,25 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/tableau/default/test publish datasource"
+                            "/prod/tableau/acryl_site1/default/test publish datasource"
                         ]
                     }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1638860400000,
-        "runId": "tableau-test"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,demo_postgres_instance.dvdrental.public.staff,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
                 },
                 {
-                    "id": "default"
-                },
-                {
-                    "id": "test publish datasource"
+                    "com.linkedin.pegasus2avro.common.BrowsePathsV2": {
+                        "path": [
+                            {
+                                "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)",
+                                "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:postgres,demo_postgres_instance)"
+                            },
+                            {
+                                "id": "default"
+                            },
+                            {
+                                "id": "test publish datasource"
+                            }
+                        ]
+                    }
                 }
             ]
         }

--- a/metadata-ingestion/tests/integration/tableau/test_tableau_ingest.py
+++ b/metadata-ingestion/tests/integration/tableau/test_tableau_ingest.py
@@ -67,6 +67,8 @@ config_source_default = {
             "config": {"datahub_api": {"server": GMS_SERVER}},
         },
     },
+    "ignore_upstream_lineage_platforms": '',
+    "upstream_postgres_database_whitelist": 'dvdrental',
 }
 
 
@@ -520,6 +522,8 @@ def test_tableau_ingest_with_platform_instance(
                 "config": {"datahub_api": {"server": GMS_SERVER}},
             },
         },
+        "ignore_upstream_lineage_platforms": '',
+        "upstream_postgres_database_whitelist": 'dvdrental',
     }
 
     tableau_ingest_common(


### PR DESCRIPTION
## Checklist


- In order to control the upstream lineage emissions from the TableauSource, we've added the ability to whitelist by db name, whenever "postgres" isn't in the `ignore_upstream_lineage_platforms` argument. `upstream_postgres_database_whitelist`, taking a comma separated list of dbs.
- Fixed a bug that resulted in ingestion breaking when the `ignore_upstream_lineage_platforms` argument was missing.
- Updated integration tests in the fork to work for the `ignore_upstream_lineage_platforms` and `upstream_postgres_database_whitelist` args
- The "golden" test files were modified when running the steps listed in the readme, so I assume they're due to some other previous change


- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
