### PR TITLE
fix(dbt): Test ingestion assertee urn issues [GDP-2226]

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
@@ -461,7 +461,7 @@ def get_upstreams(
 
         materialized = upstream_manifest_node.materialization
 
-        if materialized in {"view", "table", "incremental", "snapshot"}:
+        if materialized in {"view", "materialized_view", "table", "incremental", "snapshot", "fc_insert_by_period"}:
             # upstream urns point to the target platform
             platform_value = target_platform
             platform_instance_value = target_platform_instance
@@ -729,7 +729,7 @@ class DBTSourceBase(StatefulIngestionSourceBase):
                 target_platform=self.config.target_platform,
                 target_platform_instance=self.config.target_platform_instance,
                 environment=self.config.env,
-                platform_instance=None,
+                platform_instance=self.config.platform_instance,
             )
 
             for upstream_urn in sorted(upstream_urns):


### PR DESCRIPTION
## Description

The test ingestion assertee urn uses the target platform instance for all the non-ephemeral dbt materializations, so `fc_insert_by_period` should be included. This fixes the issue of the `fc_insert_by_period` models not showing the assertions in the UI because their urn in the assertions were missing the platform instance.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
