### PR TITLE
Check schema metadata

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau.py
@@ -144,6 +144,8 @@ from datahub.metadata.schema_classes import (
     OwnershipTypeClass,
     SubTypesClass,
     ViewPropertiesClass,
+    SchemaMetadataClass,
+    EditableSchemaMetadataClass
 )
 from datahub.sql_parsing.sql_parsing_result_utils import (
     transform_parsing_result_to_in_tables_schemas,
@@ -2250,7 +2252,13 @@ class TableauSource(StatefulIngestionSourceBase, TestableSource):
             tableau_columns, database_table.parsed_columns
         )
         if schema_metadata is not None:
-            dataset_snapshot.aspects.append(schema_metadata)
+            # Check if table already has schema metadata
+            current_schema_aspect = self.ctx.graph.get_aspect(entity_urn=database_table.urn, aspect_type=SchemaMetadataClass)
+            current_editable_schema_aspect = self.ctx.graph.get_aspect(entity_urn=database_table.urn, aspect_type=EditableSchemaMetadataClass)
+            if current_schema_aspect or current_editable_schema_aspect:
+                logger.debug(f"Table {database_table.urn} already has schema metadata, skipping")
+            else:
+                dataset_snapshot.aspects.append(schema_metadata)
 
         yield self.get_metadata_change_event(dataset_snapshot)
 


### PR DESCRIPTION
## Ticket : [GDP-2765](https://fundingcircle.atlassian.net/browse/GDP-2765)

This PR adds a fix for overwriting schemas via Tableau dataset ingestion. 

Tableau uses backing datasets to visualize charts and maintain their workbooks. During ingestion of Tableau assets, the underlying dataset ingestion overwrites the original source schema. 

[more informations](https://github.com/FundingCircle/fc-datahub/pull/205) 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


[GDP-2765]: https://fundingcircle.atlassian.net/browse/GDP-2765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ