### PR TITLE
fix(ingestion/tableau): skip upstream postgres tables without database

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,7 +15,7 @@ anchors:
       - setup 
 
   docker_build_config: &docker_build_config
-    image: plugins/ecr
+    image: plugins/ecr:20.18.5
     environment:
       ARTIFACTORY_PASSWORD:
         from_secret: ARTIFACTORY_PASSWORD

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -75,7 +75,7 @@ kafka_common = {
     # now provide prebuilt wheels for most platforms, including M1 Macs and
     # Linux aarch64 (e.g. Docker's linux/arm64). Installing confluent_kafka
     # from source remains a pain.
-    "confluent_kafka>=1.9.0",
+    "confluent_kafka[schemaregistry]>=1.9.0",
     # We currently require both Avro libraries. The codegen uses avro-python3 (above)
     # schema parsers at runtime for generating and reading JSON into Python objects.
     # At the same time, we use Kafka's AvroSerializer, which internally relies on
@@ -428,7 +428,7 @@ all_exclude_plugins: Set[str] = {
 
 mypy_stubs = {
     "types-dataclasses",
-    "types-pkg_resources",
+    "types-setuptools",
     "types-six",
     "types-python-dateutil",
     # We need to avoid 2.31.0.5 and 2.31.0.4 due to

--- a/metadata-ingestion/src/datahub/ingestion/source/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau.py
@@ -1149,10 +1149,12 @@ class TableauSource(StatefulIngestionSourceBase, TestableSource):
 
             # skip upstream tables if the source is postgres and the database is not whitelisted
             if table.get(c.CONNECTION_TYPE) == "postgres":
-                upstream_db = table.get(c.DATABASE, {}).get(c.NAME, "")
+                upstream_db = table.get(c.DATABASE, {})
+                if upstream_db:
+                    upstream_db = upstream_db.get(c.NAME, "")
                 if (
-                    upstream_db
-                    and upstream_db not in self.upstream_postgres_database_whitelist
+                    upstream_db is None # If database name is not present, skip the table
+                    or upstream_db not in self.upstream_postgres_database_whitelist
                 ):
                     logger.debug(
                         f"Skipping upstream table {table[c.ID]}, database {upstream_db} not whitelisted"


### PR DESCRIPTION
## Description

Change tableau Postgres upstream whitelist check to work when the table doesn't have a database.
Updated dependencies that were causing devInstall to fail.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
